### PR TITLE
#PLAT-0002 update tools configs

### DIFF
--- a/tools/biggie/biggie-MacOSX-compile.sh
+++ b/tools/biggie/biggie-MacOSX-compile.sh
@@ -4,7 +4,7 @@
 
 /usr/bin/gcc                                       \
     -D _MACOSX                                     \
-    -I /Library/Frameworks/SDL2.framework/Headers  \
+    -I ../../Mac/SDL2.framework/Headers            \
     -I ../../src/SDL                               \
     -I ../../src/ThirdParty/CRC                    \
     -I ../../src/ThirdParty/LZSS                   \

--- a/tools/kas2c/kas2c-MacOSX-compile.sh
+++ b/tools/kas2c/kas2c-MacOSX-compile.sh
@@ -11,7 +11,7 @@
 
 /usr/bin/gcc                                       \
     -D_MACOSX                                      \
-    -I /Library/Frameworks/SDL2.framework/Headers   \
+    -I ../../Mac/SDL2.framework/Headers            \
     *.c                                            \
     -o kas2c
 


### PR DESCRIPTION
Closes #1 

This will fix the errors mentioned in the issue about the missing `SDL_stdinc.h` header file.