### PR TITLE
#GAME-0003 add P1MissileCorvette ammo counter to all select LODs

### DIFF
--- a/src/Game/Select.c
+++ b/src/Game/Select.c
@@ -1303,7 +1303,7 @@ void selStatusDraw0(Ship *ship)
         fontMakeCurrent(selGroupFont0);
         fontPrint(x - halfWidth - fontWidth("C") - 1, rect.y1 + 5 - fontHeight(" "), selHotKeyNumberColor, "C");
     }
-    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette))      //ship has missles, so display missile status
+    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette) || (ship->shiptype == P1MissileCorvette))      //ship has missles, so display missile status
     {
         GunStatic *gunstatic;
         numGuns = ship->gunInfo->numGuns;
@@ -1552,7 +1552,7 @@ void selStatusDraw1(Ship *ship)
         fontMakeCurrent(selGroupFont1);
         fontPrint(x - halfWidth - fontWidth("C") - 1,rect.y1 + 4 - fontHeight(" ") , selHotKeyNumberColor, "C");
     }
-    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette))     //ship has missles, so display missile status
+    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette) || (ship->shiptype == P1MissileCorvette))     //ship has missles, so display missile status
     {
         GunStatic *gunstatic;
         numGuns = ship->gunInfo->numGuns;
@@ -1771,7 +1771,7 @@ void selStatusDraw2(Ship *ship)
             tutPointerShipGroupRect->y1 = rect.y1 + 3 + 2;
         }
     }
-    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette))    //ship has missles, so display missile status
+    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette) || (ship->shiptype == P1MissileCorvette))    //ship has missles, so display missile status
     {
         GunStatic *gunstatic;
         numGuns = ship->gunInfo->numGuns;


### PR DESCRIPTION
> Just like PR #4 but with all of the selection LODs included this time. All reviews from the original PR still apply.

Prints the standard ammunition counter to Turanic Raider missile corvettes.

![image](https://user-images.githubusercontent.com/14324391/100450470-a8f75d80-30f0-11eb-897c-96433ad2d832.png)
