### PR TITLE
#10 Add P1IonArrayFrigate cloak with mana pool

### DIFF
--- a/HomeworldSDL_big/files.txt
+++ b/HomeworldSDL_big/files.txt
@@ -877,6 +877,7 @@ r2\lightcorvette.mad.64
 r2\heavyinterceptor.mad.64
 p2\p2fuelpod.mad.64
 p1\p1ionarrayfrigate.mad.64
+p1\p1ionarrayfrigate.shp
 traders\junkyarddawg.mad.64
 textures.ll.64
 nis\m02a.nis.64

--- a/HomeworldSDL_big/p1/p1ionarrayfrigate.shp
+++ b/HomeworldSDL_big/p1/p1ionarrayfrigate.shp
@@ -28,6 +28,14 @@ repairDamage                        0                           ; this much dama
 blastRadiusShockWave                1.75
 blastRadiusDamage                   275
 
+;Cloaking Device Stats
+;=--------------=
+CloakingTime                        0.05                           ; Cloaking Time in seconds
+DeCloakingTime                      0.1                           ; Decloaking time
+VisibleState                        0.1                           ; Point at which ship becomes 'invisible' to sensors, ships, and everything else
+                                                                 ; Visually: 1.0 is completly vissible, and 0.0 is completly invisible
+battleReCloakTime                   2.2                           ; seconds after ship fires that it starts recloaking
+
 ;Moving Around
 ;=-----------=
 thruststrength[TRANS_UP]            50.0                         ; acceleration (m/s^2) [1-1000 approx. range]

--- a/HomeworldSDL_big/p1/p1ionarrayfrigate.shp
+++ b/HomeworldSDL_big/p1/p1ionarrayfrigate.shp
@@ -1,0 +1,150 @@
+[P1IonArrayFrigate]
+
+;Source Files
+;=----------=
+LODFile                             P1IonArrayFrigate.lod
+pMexData                            P1IonArrayFrigate\Rl0\LOD0\P1IonArrayFrigate.mex
+
+;Ship Physics
+;=----------=
+mass                                400.0                          ; ship mass [fighter = 1]
+momentOfInertiaX                    400.0                          ; resistance to rotation
+momentOfInertiaY                    400.0                          ; [fighter = 1]
+momentOfInertiaZ                    400.0
+maxvelocity                         245.0                        ; [fighter = 1000]
+maxrot                              1.0                          ; maximum rotation speed [don't make faster than ~10]
+
+;Basic Ship Stats
+;=--------------=
+shipclass                           CLASS_Frigate
+isCapitalShip                       TRUE
+buildCost                           500                          ; resource units to build
+buildTime                           60                           ; time in seconds to build
+maxhealth                           12400                         ; hit points
+groupSize                           2                            ; size of group ships of this type tend to form
+repairTime                          90                            ; every this many seconds
+repairDamage                        0                           ; this much damage is repaired
+
+blastRadiusShockWave                1.75
+blastRadiusDamage                   275
+
+;Moving Around
+;=-----------=
+thruststrength[TRANS_UP]            50.0                         ; acceleration (m/s^2) [1-1000 approx. range]
+thruststrength[TRANS_DOWN]          50.0
+thruststrength[TRANS_RIGHT]         50.0
+thruststrength[TRANS_LEFT]          50.0
+thruststrength[TRANS_FORWARD]       50.0
+thruststrength[TRANS_BACK]          50.0
+rotstrength[ROT_YAWLEFT]            0.25                          ; rotational acceleration (deg/s^2) [0.01 - 10]
+rotstrength[ROT_YAWRIGHT]           0.25
+rotstrength[ROT_PITCHUP]            0.05
+rotstrength[ROT_PITCHDOWN]          0.05
+rotstrength[ROT_ROLLRIGHT]          0.05
+rotstrength[ROT_ROLLLEFT]           0.05
+turnspeed[TURN_YAW]                 0.3                          ; speed at which ship tries to turn (1=standard)
+turnspeed[TURN_PITCH]               0.3
+turnspeed[TURN_ROLL]                0.3
+
+rotateToRetaliate                   TRUE
+
+;Weapons
+;=-----=
+NUMBER_OF_GUNS                      1
+;(one BIG gun)
+
+GUN         0
+//Desired Range =  6500
+//ADD this amount: 280 to compensate for centrepoint
+//ADD this amount: 702 to compensate for stopping distance
+{
+Type                            GUN_Gimble
+SoundType                       GS_LargeIonCannon
+BulletType                      BULLET_Beam
+DamageLo                        20                            ; damage variance per shot - low  (continuous damage for BULLET_Beam)
+DamageHi                        25                            ; damage variance per shot - high
+MinAngle                        0
+MaxAngle                        6
+BulletLength                    7482.0                        ; visual only.  Length of bullet on screen
+BulletRange                     7482.0                        ; distance bullets travel before disappearing
+BulletSpeed                     0.0                           ; measured in m/s.
+BulletLifeTime                  1.5
+BulletMass                      0.0                           ; mass of bullet
+FireTime                        3.0                           ; fire repeat rate (reciprocal = shots/second)
+;Triggerhappy                    10.0
+}
+
+NUMBER_OF_NAV_LIGHTS           5
+
+; format is NavLight            name, type, blinkrate (in seconds), size (in meters), min LOD, texture name
+NavLight                        antenna1,       NAVLIGHT_Default, 2,   1,   0,  8,  2, etg\textures\glow32
+NavLight                        antenna2,       NAVLIGHT_Default, 2,   1,  0.5, 8,  2, etg\textures\glow32
+NavLight                        antenna3,       NAVLIGHT_Default, 2,   1,   1,  8,  2, etg\textures\glow32
+NavLight                        caution1,       NAVLIGHT_Default, 1,   0.5, 0,  7,  2, etg\textures\glow32
+NavLight                        caution2,       NAVLIGHT_Default, 1,   0.5, 0,  7,  2, etg\textures\glow32
+
+
+NUMBER_OF_SALVAGE_POINTS        2
+NUM_NEEDED_FOR_SALVAGE          2               ;number of ships needed to capture a craft
+NEED_BIGR1                      TRUE
+NEED_BIGR2                      TRUE
+WILL_FIT_CARRIER                FALSE
+
+;       format:                    name,type
+SalvagePoint                       Point1,AttachPoint
+SalvagePoint                       Point2,AttachPoint
+
+
+;Mad Animation Sillyness
+;upon creation animation state:
+;animation specified is started then paused
+;i.e:   HeaveyDefender needs to start a gun opening animation,
+;       and then pause it.
+
+;MadStartInfo        needs a starting     /Animation Text Name(no spaces allowed!)
+                     animation(1-yes,0-no)/
+MadStartInfo                   1 , Array_Open , 1 , Array_Open
+
+;MadGunAnims          definitions in explination below
+;                       n = number, g = gun, o = open, c = close, d = damaged, a = animations
+
+;                            ;ngoa,names,...,ngca,names,...,ngoda,names,... ,ngcda,names,...
+;if this doesn't
+;makes sence, ask Bryce
+MadGunAnims                     1, Array_Open, 1, Array_Close, 1,Array_Open_DMG, 1, Array_Close_DMG
+
+;Ships health must be below this percentage to use the damaged animations.
+madGunOpenDamagedHealthThreshold                0.70    ;<= 1.0f
+
+;Explosions
+;=--------=
+explosionType                       ET_FrigateExplosion
+
+BindAnimations                      1
+
+;Scaling effects
+;=--------=
+N-LIPS                              0.0001                   ; Max value for Interceptors 0.0005
+scaleFactor                         1.0                      ; Used for debugging
+
+;Engine Glow
+;=---------=
+trailWidth          70.0
+trailHeight         65.0
+trailLength         100.0
+trailStyle          3
+trailScaleCap       0.00025
+trailAngle          118
+
+;Engine Glow #2
+;=---------=
+trailWidth2         70.0
+trailHeight2        65.0
+trailLength2        100.0
+trailStyle2         3
+trailScaleCap2      0.0001
+trailAngle2         72
+
+minimumZoomDistance                 375
+
+

--- a/src/Ships/P1IonArrayFrigate.c
+++ b/src/Ships/P1IonArrayFrigate.c
@@ -71,23 +71,40 @@ void P1IonArrayFrigateInit(Ship *ship)
     spec->ReCloak = FALSE;
 }
 
+void P1IonArrayFrigateHandleFireStart(Ship *ship)
+{
+    if (ship->shiptype != P1IonArrayFrigate)
+    {
+        return;
+    }
+
+    if (bitTest(ship->flags, SOF_Cloaked) || bitTest(ship->flags, SOF_Cloaking))
+    {                                        //ship is cloaked...make it decloak...
+        bitClear(ship->flags, SOF_Cloaking); //if bastard is trying to cloak,
+        bitSet(ship->flags, SOF_DeCloaking); //put an end to it pronto!
+        real32 reCloakTimestamp = universe.totaltimeelapsed + ((P1IonArrayFrigateStatics *)((ShipStaticInfo *)(ship->staticinfo))->custstatinfo)->battleReCloakTime;
+        ((P1IonArrayFrigateSpec *)ship->ShipSpecifics)->ReCloak = TRUE;
+        ((P1IonArrayFrigateSpec *)ship->ShipSpecifics)->ReCloakTime = reCloakTimestamp;
+    }
+}
+
 void P1IonArrayFrigateAttack(Ship *ship,SpaceObjRotImpTarg *target,real32 maxdist)
 {
     ShipStaticInfo *shipstaticinfo = (ShipStaticInfo *)ship->staticinfo;
     P1IonArrayFrigateStatics *frigstat = (P1IonArrayFrigateStatics *)shipstaticinfo->custstatinfo;
 
-    attackStraightForward(ship, target, frigstat->frigateGunRange[ship->tacticstype], frigstat->frigateTooCloseRange[ship->tacticstype], NULL, NULL);
+    attackStraightForward(ship, target, frigstat->frigateGunRange[ship->tacticstype], frigstat->frigateTooCloseRange[ship->tacticstype], P1IonArrayFrigateHandleFireStart, NULL);
 }
 
 void P1IonArrayFrigateAttackPassive(Ship *ship,Ship *target,bool rotate)
 {
     if ((rotate) & ((bool)((ShipStaticInfo *)(ship->staticinfo))->rotateToRetaliate))
     {
-        attackPassiveRotate(ship, target, NULL, NULL);
+        attackPassiveRotate(ship, target, P1IonArrayFrigateHandleFireStart, NULL);
     }
     else
     {
-        attackPassive(ship, target, NULL, NULL);
+        attackPassive(ship, target, P1IonArrayFrigateHandleFireStart, NULL);
     }
 }
 

--- a/src/Ships/P1IonArrayFrigate.c
+++ b/src/Ships/P1IonArrayFrigate.c
@@ -35,6 +35,16 @@ typedef struct
 
 P1IonArrayFrigateStatics P1IonArrayFrigateStatic;
 
+scriptStructEntry P1IonArrayFrigateStaticScriptTable[] =
+{
+    { "CloakingTime",               scriptSetReal32CB,  &(P1IonArrayFrigateStatic.CloakingTime),                &(P1IonArrayFrigateStatic) },
+    { "DeCloakingTime",             scriptSetReal32CB,  &(P1IonArrayFrigateStatic.DeCloakingTime),              &(P1IonArrayFrigateStatic) },
+    { "VisibleState",               scriptSetReal32CB,  &(P1IonArrayFrigateStatic.VisibleState),                &(P1IonArrayFrigateStatic) },
+    { "battleReCloakTime",          scriptSetReal32CB,  &(P1IonArrayFrigateStatic.battleReCloakTime),           &(P1IonArrayFrigateStatic) },
+
+    END_SCRIPT_STRUCT_ENTRY
+};
+
 void P1IonArrayFrigateStaticInit(char *directory,char *filename,struct ShipStaticInfo *statinfo)
 {
     udword i;
@@ -47,6 +57,8 @@ void P1IonArrayFrigateStaticInit(char *directory,char *filename,struct ShipStati
         frigstat->frigateGunRange[i] = statinfo->bulletRange[i];
         frigstat->frigateTooCloseRange[i] = statinfo->minBulletRange[i] * 0.9f;
     }
+
+    scriptSetStruct(directory, filename, P1IonArrayFrigateStaticScriptTable, (ubyte *)frigstat);
 
     frigstat->CloakingTime = 1 / frigstat->CloakingTime;
 }

--- a/src/Ships/P1IonArrayFrigate.c
+++ b/src/Ships/P1IonArrayFrigate.c
@@ -8,17 +8,29 @@
 #include "P1IonArrayFrigate.h"
 
 #include "Attack.h"
+#include "Battle.h"
 #include "DefaultShip.h"
+#include "Gun.h"
+#include "SoundEvent.h"
+#include "Universe.h"
 
 typedef struct
 {
     udword dummy;
+    real32 CloakingStatus; // Gradient value for cloaking and decloaking state.
+    bool CloakLowWarning;  // Indicates whether the ship's cloak mana is low.
+    bool ReCloak;          // Indicates whether the ship needs to cloak again.
+    real32 ReCloakTime;    // Timestamp (in seconds) against game time elapsed during which the ship must cloak again.
 } P1IonArrayFrigateSpec;
 
 typedef struct
 {
     real32 frigateGunRange[NUM_TACTICS_TYPES];
     real32 frigateTooCloseRange[NUM_TACTICS_TYPES];
+    real32 CloakingTime;      // Cloaking delay (in seconds).
+    real32 DeCloakingTime;    // Decloaking delay (in seconds).
+    real32 VisibleState;      // Threshold at which the ship becomes "invisible" to sensors, ships and everything else.
+    real32 battleReCloakTime; // Recloaking delay (in seconds) after the ship has fired.
 } P1IonArrayFrigateStatics;
 
 P1IonArrayFrigateStatics P1IonArrayFrigateStatic;
@@ -35,6 +47,16 @@ void P1IonArrayFrigateStaticInit(char *directory,char *filename,struct ShipStati
         frigstat->frigateGunRange[i] = statinfo->bulletRange[i];
         frigstat->frigateTooCloseRange[i] = statinfo->minBulletRange[i] * 0.9f;
     }
+
+    frigstat->CloakingTime = 1 / frigstat->CloakingTime;
+}
+
+void P1IonArrayFrigateInit(Ship *ship)
+{
+    P1IonArrayFrigateSpec *spec = (P1IonArrayFrigateSpec *)ship->ShipSpecifics;
+    spec->CloakingStatus = 1.0f; //ship isn't cloaked
+    spec->CloakLowWarning = FALSE;
+    spec->ReCloak = FALSE;
 }
 
 void P1IonArrayFrigateAttack(Ship *ship,SpaceObjRotImpTarg *target,real32 maxdist)
@@ -57,20 +79,112 @@ void P1IonArrayFrigateAttackPassive(Ship *ship,Ship *target,bool rotate)
     }
 }
 
+void P1IonArrayFrigateSpecialActivate(Ship *ship)
+{
+    P1IonArrayFrigateSpec *spec = (P1IonArrayFrigateSpec *)ship->ShipSpecifics;
+    P1IonArrayFrigateStatics *stat = (P1IonArrayFrigateStatics *)((ShipStaticInfo *)(ship->staticinfo))->custstatinfo;
+
+    spec->ReCloak = FALSE;
+
+    if (bitTest(ship->flags, SOF_Cloaked))
+    {
+        bitSet(ship->flags, SOF_DeCloaking); //begin DeCloaking Process;
+        SpawnCloakingEffect(ship, etgSpecialPurposeEffectTable[EGT_CLOAK_OFF]);
+        soundEvent(ship, Ship_CloakOff);
+    }
+    else
+    {
+        bitSet(ship->flags, SOF_Cloaking); //begin Cloaking Process
+        SpawnCloakingEffect(ship, etgSpecialPurposeEffectTable[EGT_CLOAK_ON]);
+        soundEvent(ship, Ship_CloakOn);
+        if (battleCanChatterAtThisTime(BCE_CloakingOn, ship))
+        {
+            battleChatterAttempt(SOUND_EVENT_DEFAULT, BCE_CloakingOn, ship, SOUND_EVENT_DEFAULT);
+        }
+    }
+
+    return TRUE;
+}
+
+void P1IonArrayFrigateHouseKeep(Ship *ship)
+{
+    P1IonArrayFrigateSpec *spec = (P1IonArrayFrigateSpec *)ship->ShipSpecifics;
+    P1IonArrayFrigateStatics *stat = (P1IonArrayFrigateStatics *)((ShipStaticInfo *)(ship->staticinfo))->custstatinfo;
+
+    if (bitTest(ship->flags, SOF_Cloaking)) //ship is cloaking
+    {
+        //decrement Cloaking Status counter based on time elapsed
+        /***** calculated the inverse of CloakingTime in P1IonArrayFrigateStaticInit and multiply instead of divide *****/
+        spec->CloakingStatus -= universe.phystimeelapsed * stat->CloakingTime;
+        if (spec->CloakingStatus <= stat->VisibleState)
+        {                                     //if ship is now past the vissible threshold
+            bitSet(ship->flags, SOF_Cloaked); //make it invisible to everything
+            if (spec->CloakingStatus <= 0.0f) //if it is completly invisible stop decloaking
+            {
+                spec->CloakingStatus = 0.0f;         //reset to 0.0
+                bitClear(ship->flags, SOF_Cloaking); //stop ship from 'cloaking'
+                //Since ship is cloaked, must remove it from being targeted
+                //Note:  This probably will not let a person attack their own cloaked ships...
+
+                shipHasJustCloaked(ship);
+            }
+        }
+    }
+    else if (bitTest(ship->flags, SOF_DeCloaking)) //Ship is decloaking
+    {
+        //Increment Cloaking Status counter based on time elapsed
+        /***** calculated the inverse of CloakingTime in P1IonArrayFrigateStaticInit and multiply instead of divide *****/
+        spec->CloakingStatus += universe.phystimeelapsed * stat->CloakingTime;
+        if (spec->CloakingStatus >= stat->VisibleState)
+        { //ship is 'visible' since it is past visible threshold
+            if (ship->flags & SOF_Cloaked)
+            {
+                bitClear(ship->flags, SOF_Cloaked);
+                ship->shipDeCloakTime = universe.totaltimeelapsed;
+            }
+            if (spec->CloakingStatus >= 1.0f) //done decloaking
+            {
+                spec->CloakingStatus = 1.0f;
+                bitClear(ship->flags, SOF_DeCloaking);
+                spec->CloakLowWarning = FALSE; //reset flag
+                if (spec->ReCloak == FALSE)
+                { //only play speech when really decloaking for good
+                    if (battleCanChatterAtThisTime(BCE_Decloaking, ship))
+                    {
+                        battleChatterAttempt(SOUND_EVENT_DEFAULT, BCE_Decloaking, ship, SOUND_EVENT_DEFAULT);
+                    }
+                }
+            }
+        }
+    }
+
+    // TODO: @kajitetsushi Consume energy for running cloak. See the cloak generator for ideas.
+
+    if (spec->ReCloak == TRUE)
+    {
+        if (universe.totaltimeelapsed > spec->ReCloakTime)
+        {
+            spec->ReCloak = FALSE;
+            bitSet(ship->flags, SOF_Cloaking);
+            soundEvent(ship, Ship_CloakOn);
+        }
+    }
+}
+
 CustShipHeader P1IonArrayFrigateHeader =
 {
     P1IonArrayFrigate,
     sizeof(P1IonArrayFrigateSpec),
     P1IonArrayFrigateStaticInit,
     NULL,
-    NULL,
+    P1IonArrayFrigateInit,
     NULL,
     P1IonArrayFrigateAttack,
     DefaultShipFire,
     P1IonArrayFrigateAttackPassive,
+    P1IonArrayFrigateSpecialActivate,
     NULL,
-    NULL,
-    NULL,
+    P1IonArrayFrigateHouseKeep,
     NULL,
     NULL,
     NULL,


### PR DESCRIPTION
Closes #10 

- [x] Add primitive cloak.
- [x] Use `onFire*(ship)` callback to decloak the `P1IonArrayFrigate` after firing.
- [ ] Add mana to limit the use of the cloak special ability.
- [x] Add customizable key-value pairs for the `P1IonArrayFrigate` cloaking ability.