### PR TITLE
#3 count P1MissileCorvette ammo

### DIFF
--- a/src/Game/Select.c
+++ b/src/Game/Select.c
@@ -1303,7 +1303,7 @@ void selStatusDraw0(Ship *ship)
         fontMakeCurrent(selGroupFont0);
         fontPrint(x - halfWidth - fontWidth("C") - 1, rect.y1 + 5 - fontHeight(" "), selHotKeyNumberColor, "C");
     }
-    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette))      //ship has missles, so display missile status
+    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette) || (ship->shiptype == P1MissileCorvette))      //ship has missles, so display missile status
     {
         GunStatic *gunstatic;
         numGuns = ship->gunInfo->numGuns;
@@ -1552,7 +1552,7 @@ void selStatusDraw1(Ship *ship)
         fontMakeCurrent(selGroupFont1);
         fontPrint(x - halfWidth - fontWidth("C") - 1,rect.y1 + 4 - fontHeight(" ") , selHotKeyNumberColor, "C");
     }
-    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette))     //ship has missles, so display missile status
+    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette) || (ship->shiptype == P1MissileCorvette))     //ship has missles, so display missile status
     {
         GunStatic *gunstatic;
         numGuns = ship->gunInfo->numGuns;
@@ -1771,7 +1771,7 @@ void selStatusDraw2(Ship *ship)
             tutPointerShipGroupRect->y1 = rect.y1 + 3 + 2;
         }
     }
-    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette))    //ship has missles, so display missile status
+    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette) || (ship->shiptype == P1MissileCorvette))    //ship has missles, so display missile status
     {
         GunStatic *gunstatic;
         numGuns = ship->gunInfo->numGuns;

--- a/src/Game/Select.c
+++ b/src/Game/Select.c
@@ -1225,6 +1225,51 @@ void selSelectionDraw5(Ship *ship)      // PLEASE DON'T COMMENT THIS FUNCTION OU
 }
 #endif
 
+/**
+ * @brief Prints the ammunition counter if the ship has ammunition.
+ * 
+ * @param ship The reference ship.
+ * @param font Font to use for the particular LOD.
+ * @param x Coordinates to print on screen from the left.
+ * @param y Coordinates to print on screen from the top.
+ * @param c Color to draw the counter text in.
+ */
+void selFontPrintAmmoAtLod(
+    Ship *ship,      // The reference ship.
+    fonthandle font, // Font to use for the particular LOD.
+    sdword x,        // Coordinates to print on screen from the left.
+    sdword y,        // Coordinates to print on screen from the top.
+    color c          // Color to draw the counter text in.
+)
+{
+    ShipStaticInfo *stat = (ShipStaticInfo *)ship->staticinfo;
+    if (!stat->hasAmmo) 
+    {
+        return;
+    }
+
+    // Loop through each gun and accumulate ammo.
+    GunStatic *gunstatic;
+    sdword noOfRounds = 0;
+    sdword noOfGuns = ship->gunInfo->numGuns;
+    sdword index;
+    for (index = 0; index < noOfGuns; index++)
+    {
+        gunstatic = &((ShipStaticInfo *)ship->staticinfo)->gunStaticInfo->gunstatics[index];
+        if (!gunstatic->maxMissiles)
+        {
+            continue;
+        }
+        Gun *gun;
+        gun = &ship->gunInfo->guns[index];
+        noOfRounds += gun->numMissiles;
+    }
+
+    // Print them.
+    fontMakeCurrent(font);
+    fontPrintf(x, y, c, "%d", noOfRounds);
+}
+
 //lod0: health/fuel with outline and hollow centre
 void selStatusDraw0(Ship *ship)
 {
@@ -1303,24 +1348,8 @@ void selStatusDraw0(Ship *ship)
         fontMakeCurrent(selGroupFont0);
         fontPrint(x - halfWidth - fontWidth("C") - 1, rect.y1 + 5 - fontHeight(" "), selHotKeyNumberColor, "C");
     }
-    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette) || (ship->shiptype == P1MissileCorvette))      //ship has missles, so display missile status
-    {
-        GunStatic *gunstatic;
-        numGuns = ship->gunInfo->numGuns;
-        for (i=0;i < numGuns;i++)
-        {
-            //gunstatic = ((ShipStaticInfo *)ship->staticinfo)->gunStaticInfo->gunstatics[i];
-            gunstatic = &((ShipStaticInfo *)ship->staticinfo)->gunStaticInfo->gunstatics[i];
-            if (gunstatic->guntype == GUN_MissileLauncher || gunstatic->guntype == GUN_MineLauncher)
-            {
-                Gun *gun;
-                gun = &ship->gunInfo->guns[i];
-                missilecount += gun->numMissiles;
-            }
-        }
-        fontMakeCurrent(selGroupFont0);
-        fontPrintf(x - halfWidth , rect.y1 + 5, selHotKeyNumberColor, "%d", missilecount);
-    }
+
+    selFontPrintAmmoAtLod(ship, selGroupFont0, x - halfWidth, rect.y1 + 5, selHotKeyNumberColor);
 
     maxFuel = ((ShipStaticInfo *)ship->staticinfo)->maxfuel;
     maxResources = ((ShipStaticInfo *)ship->staticinfo)->maxresources;
@@ -1552,25 +1581,8 @@ void selStatusDraw1(Ship *ship)
         fontMakeCurrent(selGroupFont1);
         fontPrint(x - halfWidth - fontWidth("C") - 1,rect.y1 + 4 - fontHeight(" ") , selHotKeyNumberColor, "C");
     }
-    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette) || (ship->shiptype == P1MissileCorvette))     //ship has missles, so display missile status
-    {
-        GunStatic *gunstatic;
-        numGuns = ship->gunInfo->numGuns;
-        for (i=0;i < numGuns;i++)
-        {
-            //gunstatic = ((ShipStaticInfo *)ship->staticinfo)->gunStaticInfo->gunstatics[i];
-            gunstatic = &((ShipStaticInfo *)ship->staticinfo)->gunStaticInfo->gunstatics[i];
-            if (gunstatic->guntype == GUN_MissileLauncher || gunstatic->guntype == GUN_MineLauncher)
-            {
-                Gun *gun;
-                gun = &ship->gunInfo->guns[i];
-                missilecount += gun->numMissiles;
-            }
-        }
-        fontMakeCurrent(selGroupFont1);
-        fontPrintf(x - halfWidth , rect.y1 + 4, selHotKeyNumberColor, "%d", missilecount);
-    }
 
+    selFontPrintAmmoAtLod(ship, selGroupFont1, x - halfWidth, rect.y1 + 4, selHotKeyNumberColor);
 
     maxFuel = ((ShipStaticInfo *)ship->staticinfo)->maxfuel;
     maxResources = ((ShipStaticInfo *)ship->staticinfo)->maxresources;
@@ -1771,24 +1783,8 @@ void selStatusDraw2(Ship *ship)
             tutPointerShipGroupRect->y1 = rect.y1 + 3 + 2;
         }
     }
-    if((ship->shiptype == MissileDestroyer) || (ship->shiptype == MinelayerCorvette) || (ship->shiptype == P1MissileCorvette))    //ship has missles, so display missile status
-    {
-        GunStatic *gunstatic;
-        numGuns = ship->gunInfo->numGuns;
-        for (i=0;i < numGuns;i++)
-        {
-            //gunstatic = ((ShipStaticInfo *)ship->staticinfo)->gunStaticInfo->gunstatics[i];
-            gunstatic = &((ShipStaticInfo *)ship->staticinfo)->gunStaticInfo->gunstatics[i];
-            if (gunstatic->guntype == GUN_MissileLauncher || gunstatic->guntype == GUN_MineLauncher)
-            {
-                Gun *gun;
-                gun = &ship->gunInfo->guns[i];
-                missilecount += gun->numMissiles;
-            }
-        }
-        fontMakeCurrent(selGroupFont2);
-        fontPrintf(x - halfWidth , rect.y1 + 1, selHotKeyNumberColor, "%d", missilecount);
-    }
+
+    selFontPrintAmmoAtLod(ship, selGroupFont2, x - halfWidth, rect.y1 + 1, selHotKeyNumberColor);
 
     //Add cloaking Status if ship is for some reason cloaked...
     if(bitTest(ship->flags,SOF_Cloaked))    //if the ship is cloaked

--- a/src/Game/SpaceObj.h
+++ b/src/Game/SpaceObj.h
@@ -589,6 +589,7 @@ typedef struct ShipStaticInfo
     bool8 canTargetMultipleTargets;
     bool8 rotateToRetaliate;
     bool8 canReceiveTheseShips[4];
+    bool8 hasAmmo; // Indicates whether at least one of the ship's weapons carry ammunition.
 
     bool passiveAttackPenaltyExempt;
 

--- a/src/Game/Universe.c
+++ b/src/Game/Universe.c
@@ -2247,9 +2247,14 @@ void InitStatShipInfo(ShipStaticInfo *statinfo,ShipType type,ShipRace race)
     if (statinfo->gunStaticInfo != NULL)
     {
         GunStaticInfo *gunstaticinfo = statinfo->gunStaticInfo;
+        GunStatic *gunstatic;
         for (i=0;i<gunstaticinfo->numGuns;i++)
         {
             gunstaticinfo->gunstatics[i].gunindex = i;
+            gunstatic = &(statinfo)->gunStaticInfo->gunstatics[i];
+
+            // Precompute indication that this ship will carry ammunition.
+            statinfo->hasAmmo = statinfo->hasAmmo || gunstatic->maxMissiles;
         }
         mexGetGunStaticInfo(gunstaticinfo,statinfo->staticheader.pMexData);
     }
@@ -2261,7 +2266,6 @@ void InitStatShipInfo(ShipStaticInfo *statinfo,ShipType type,ShipRace race)
             statinfo->bulletRangeSquared[i] = statinfo->bulletRange[i] * statinfo->bulletRange[i];
         }
     }
-
 
     //load in the hierarchy binding information
     scriptSetStruct(directory,shipname,HierarchyBindingTable,(ubyte *)statinfo);


### PR DESCRIPTION
Fixes #3

This change simplifies the API a bit in terms of implementation.

It also benefits the modders in terms of avoiding additional cognitive overhead when modding ship details. Any ship carrying any weapon will now be able to show an ammo counter, regardless of the ship type and ship weapon type.

![image](https://user-images.githubusercontent.com/14324391/101246187-b34ad480-374c-11eb-88b2-710590eaba35.png)

# Checklist
- [x] add `P1MissileCorvette` to ammo counter LOD display filter
- [x] convert to reusable logic

# Changelog
- The missile counter is no longer fixed to counting missile destroyer and minelayer corvette ship types. As long as the ship has a `GUN_MissileLauncher` in its app settings file (`*.shp`) and `MaxMissiles` is greater than 0, the counter will apply.

# Known issues
- When `MaxMissiles` in the `.script` files is `0` or not declared at all, the ship selection UI will not display the ammo counter. This is a necessary evil considering that `NULL` checks don't work against `maxMissiles`. We will visit this in the future when a solution exists to print `0` as well.