### PR TITLE
#4 restore P1MissileCorvette volley fire

### DIFF
--- a/src/SDL/mouse.c
+++ b/src/SDL/mouse.c
@@ -1332,6 +1332,7 @@ void mouseSelectCursorSetting(void)
             {
                 case MissileDestroyer:
                 case HeavyCorvette:
+                case P1MissileCorvette:
                     bitSet(mouseInfo.flags, MCF_SpecialAttack);
                     break;
                 case Carrier:

--- a/src/Ships/MissileDestroyer.c
+++ b/src/Ships/MissileDestroyer.c
@@ -18,7 +18,6 @@
 #include "StatScript.h"
 #include "Universe.h"
 
-
 #define VOLLEY_BEGIN        10
 #define VOLLEY_NOT_BEGIN    20
 


### PR DESCRIPTION
Fixes #4

Demo 1: https://youtu.be/sDsH_smkWNk
Demo 2: https://youtu.be/2PDyNXJUzBs

## Checklist
- [x] add `P1MissileCorvette` to special attack ability filter
- [x] add `MissileDestroyer` battle chatter to `P1MissileCorvette`
- [x] ~~reuse **all** of `MissileDestroyer`'s "special target" logic~~ **EDIT:** tried it, didn't work https://youtu.be/00o_PZQPHhw
- [x] ~~convert to reusable logic~~ **EDIT:** uh-huh, nope! #22 

## Changelog
- The Turanic Raider missile corvette (`P1MissileCorvette`) can now properly use volley fire special ability, like the missile destroyer, with voice feedback included.

## Known issues
- The missile corvette drifts when using the volley attack.