### PR TITLE
Add missing extern declarations in header files

### DIFF
--- a/src/Game/NIS.h
+++ b/src/Game/NIS.h
@@ -376,7 +376,7 @@ extern bool nisPrintInfo;
 extern bool nisNoLockout;
 #endif
 #if NIS_TEST
-nisplaying *testPlaying;
+extern nisplaying *testPlaying;
 #endif
 
 extern nisplaying *thisNisPlaying;

--- a/src/SDL/TitanInterfaceC.h
+++ b/src/SDL/TitanInterfaceC.h
@@ -322,7 +322,7 @@ void titanLeaveGame(int shutdown);
 #define REQUEST_RECV_CB_JUSTDENY        0
 #define REQUEST_RECV_CB_ACCEPT          1
 
-enum { GAME_NOT_STARTED, GAME_STARTING, GAME_STARTED } mGameCreationState;
+extern enum { GAME_NOT_STARTED, GAME_STARTING, GAME_STARTED } mGameCreationState;
 
 signed long titanRequestReceivedCB(Address *address,const void *blob,unsigned short bloblen);
 
@@ -471,4 +471,3 @@ void titanWaitShutdown(void);
 void titanConnectingCancelHit(void);
 
 #endif
-

--- a/src/SDL/main.h
+++ b/src/SDL/main.h
@@ -15,13 +15,13 @@
 // -----------------------------------------------------------------------------
 // Make sure the game is being compiled with the correct build configuration
 // -----------------------------------------------------------------------------
- 
+
 #define HW_GAME_TYPE_COUNT    defined( HW_GAME_HOMEWORLD      ) \
                             + defined( HW_GAME_RAIDER_RETREAT ) \
                             + defined( HW_GAME_DEMO           )
 
 #define HW_BUILD_TYPE_COUNT   defined( HW_BUILD_FOR_DEBUGGING    ) \
-                            + defined( HW_BUILD_FOR_DISTRIBUTION ) 
+                            + defined( HW_BUILD_FOR_DISTRIBUTION )
 
 
 #if HW_GAME_TYPE_COUNT != 1
@@ -89,7 +89,7 @@ commandoption;
 extern void *ghMainWindow;
 extern void *ghInstance;
 #if MAIN_SENSOR_LEVEL
-udword initialSensorLevel;
+extern udword initialSensorLevel;
 #endif
 
 extern sdword enableTrails;

--- a/src/SDL/mainrgn.h
+++ b/src/SDL/mainrgn.h
@@ -91,7 +91,7 @@ extern real32 mrLastKeyTime;
 extern bool mrDisabled;
 
 #if MR_CAN_FOCUS_ROIDS
-bool mrCanFocusRoids;
+extern bool mrCanFocusRoids;
 #endif
 
 /*=============================================================================

--- a/src/SDL/render.h
+++ b/src/SDL/render.h
@@ -105,12 +105,12 @@ extern udword rndLightingEnabled;
 extern bool rndScissorEnabled;
 
 #if RND_POLY_STATS
-sdword rndDisplayPolyStats;
-sdword rndNumberPolys;
-sdword rndNumberTextured;
-sdword rndNumberSmoothed;
-sdword rndNumberDots;
-sdword rndNumberLines;
+extern sdword rndDisplayPolyStats;
+extern sdword rndNumberPolys;
+extern sdword rndNumberTextured;
+extern sdword rndNumberSmoothed;
+extern sdword rndNumberDots;
+extern sdword rndNumberLines;
 #endif
 
 #if RND_PLUG_DISABLEABLE


### PR DESCRIPTION
This allows building with modern more strict compilers e.g. gcc 10