### PR TITLE
Fix bad UI rendering issue

### DIFF
--- a/src/SDL/prim2d.h
+++ b/src/SDL/prim2d.h
@@ -74,8 +74,8 @@ extern sdword primModeEnabled;
 #define primModeSet2() if (!primModeEnabled) primModeSetFunction2();
 #define primModeClear2() if (primModeEnabled) primModeClearFunction2();
 
-#define primScreenToGLX(x) (((real32)(x)+0.325f) / (real32)(MAIN_WindowWidth) * 2.0f - 1.0f)
-#define primScreenToGLY(y) (1.0f - ((real32)(y)+0.325f) / (real32)(MAIN_WindowHeight) * 2.0f)
+#define primScreenToGLX(x) (((real32)(x)) / (real32)(MAIN_WindowWidth) * 2.0f - 1.0f)
+#define primScreenToGLY(y) (1.0f - ((real32)(y)) / (real32)(MAIN_WindowHeight) * 2.0f)
 #define primScreenToGLScaleX(x) ((real32)(x) / (real32)(MAIN_WindowWidth) * 2.0f)
 #define primScreenToGLScaleY(y) ((real32)(y) / (real32)(MAIN_WindowHeight) * 2.0f)
 #define primGLToScreenX(x) (MAIN_WindowWidth / 2 + (sdword)((x) * (real32)MAIN_WindowWidth / 2.0f))


### PR DESCRIPTION
Depending on choosen resolution, especially on very high ones (full HD+) the UI including the mouse cursor has some rendering errors due to sampling from wrong texture positions. This is due to how the rects are put into screen space coordinates.

(since I currently only have one system to test on - please actually test this)