### PR TITLE
#22 add volfire and ammo shared modules

### DIFF
--- a/Mac/Homeworld.xcodeproj/project.pbxproj
+++ b/Mac/Homeworld.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		091AFDE0258625430027A01D /* VolleyFire.c in Sources */ = {isa = PBXBuildFile; fileRef = 091AFDDF258625430027A01D /* VolleyFire.c */; };
+		091AFDE1258625430027A01D /* VolleyFire.c in Sources */ = {isa = PBXBuildFile; fileRef = 091AFDDF258625430027A01D /* VolleyFire.c */; };
+		091AFDE5258F7CC20027A01D /* Ammunition.c in Sources */ = {isa = PBXBuildFile; fileRef = 091AFDE2258F7CC10027A01D /* Ammunition.c */; };
+		091AFDE6258F7F6F0027A01D /* Ammunition.c in Sources */ = {isa = PBXBuildFile; fileRef = 091AFDE2258F7CC10027A01D /* Ammunition.c */; };
 		174F9C6A239017B10087B2DB /* SDL2.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1793E3D6237095FD006F67CB /* SDL2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1793E3D7237095FD006F67CB /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1793E3D6237095FD006F67CB /* SDL2.framework */; };
 		1793E3D8237095FD006F67CB /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1793E3D6237095FD006F67CB /* SDL2.framework */; };
@@ -619,6 +623,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		091AFDDE258625430027A01D /* VolleyFire.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = VolleyFire.h; path = ../src/Game/VolleyFire.h; sourceTree = SOURCE_ROOT; };
+		091AFDDF258625430027A01D /* VolleyFire.c */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.c; name = VolleyFire.c; path = ../src/Game/VolleyFire.c; sourceTree = SOURCE_ROOT; };
+		091AFDE2258F7CC10027A01D /* Ammunition.c */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.c; name = Ammunition.c; path = ../src/Game/Ammunition.c; sourceTree = SOURCE_ROOT; };
+		091AFDE3258F7CC10027A01D /* Ammunition.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = Ammunition.h; path = ../src/Game/Ammunition.h; sourceTree = SOURCE_ROOT; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		1793E3D6237095FD006F67CB /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SDL2.framework; sourceTree = "<group>"; };
 		1793E3E12371F080006F67CB /* Homeworld.big */ = {isa = PBXFileReference; lastKnownFileType = file; name = Homeworld.big; path = ../Homeworld.big; sourceTree = "<group>"; };
@@ -1523,6 +1531,8 @@
 		90623BED064992AE0088361C /* Game */ = {
 			isa = PBXGroup;
 			children = (
+				091AFDE2258F7CC10027A01D /* Ammunition.c */,
+				091AFDE3258F7CC10027A01D /* Ammunition.h */,
 				90623BEE064992AE0088361C /* AIAttackMan.c */,
 				90623BEF064992AE0088361C /* AIAttackMan.h */,
 				90623BF0064992AE0088361C /* AIDefenseMan.c */,
@@ -1813,6 +1823,8 @@
 				90623D1B064992AF0088361C /* Vector.c */,
 				90623D1C064992AF0088361C /* Vector.h */,
 				90623D1D064992AF0088361C /* VolTweakDefs.h */,
+				091AFDDE258625430027A01D /* VolleyFire.h */,
+				091AFDDF258625430027A01D /* VolleyFire.c */,
 				90623D1E064992AF0088361C /* Volume.c */,
 				90623D1F064992AF0088361C /* Volume.h */,
 			);
@@ -2341,6 +2353,7 @@
 				3516C955077C41B0001AA863 /* AIVar.c in Sources */,
 				3516C956077C41B0001AA863 /* Alliance.c in Sources */,
 				3516C957077C41B0001AA863 /* Animatic.c in Sources */,
+				091AFDE5258F7CC20027A01D /* Ammunition.c in Sources */,
 				3516C958077C41B0001AA863 /* Attack.c in Sources */,
 				3516C959077C41B0001AA863 /* AutoDownloadMap.c in Sources */,
 				3516C95A077C41B0001AA863 /* AutoLOD.c in Sources */,
@@ -2456,6 +2469,7 @@
 				3516C9CD077C41B0001AA863 /* Universe.c in Sources */,
 				3516C9CE077C41B0001AA863 /* UnivUpdate.c in Sources */,
 				3516C9CF077C41B0001AA863 /* Vector.c in Sources */,
+				091AFDE1258625430027A01D /* VolleyFire.c in Sources */,
 				3516C9D0077C41B0001AA863 /* Volume.c in Sources */,
 				3516CA23077C41B0001AA863 /* font.c in Sources */,
 				3516CA2B077C41B0001AA863 /* mainrgn.c in Sources */,
@@ -2635,6 +2649,7 @@
 				90623D3C064992AF0088361C /* AIUtilities.c in Sources */,
 				90623D3E064992AF0088361C /* AIVar.c in Sources */,
 				90623D40064992AF0088361C /* Alliance.c in Sources */,
+				091AFDE6258F7F6F0027A01D /* Ammunition.c in Sources */,
 				90623D42064992AF0088361C /* Animatic.c in Sources */,
 				90623D44064992AF0088361C /* Attack.c in Sources */,
 				90623D47064992AF0088361C /* AutoDownloadMap.c in Sources */,
@@ -2751,6 +2766,7 @@
 				90623E49064992AF0088361C /* Universe.c in Sources */,
 				90623E4B064992AF0088361C /* UnivUpdate.c in Sources */,
 				90623E4D064992AF0088361C /* Vector.c in Sources */,
+				091AFDE0258625430027A01D /* VolleyFire.c in Sources */,
 				90623E50064992AF0088361C /* Volume.c in Sources */,
 				90BD926A064AEE7B003E3D39 /* font.c in Sources */,
 				90BD9285064AEE7B003E3D39 /* mouse.c in Sources */,

--- a/Windows/prj/hwsdl.vcproj
+++ b/Windows/prj/hwsdl.vcproj
@@ -349,6 +349,9 @@
 				RelativePath="..\..\src\Game\Alliance.c">
 			</File>
 			<File
+				RelativePath="..\..\src\Game\Ammunition.c">
+			</File>
+			<File
 				RelativePath="..\..\src\Game\Animatic.c">
 			</File>
 			<File
@@ -1222,6 +1225,9 @@
 				RelativePath="..\..\src\Game\Vector.c">
 			</File>
 			<File
+				RelativePath="..\..\src\Game\VolleyFire.c">
+			</File>
+			<File
 				RelativePath="..\..\src\Game\Volume.c">
 			</File>
 			<File
@@ -1369,6 +1375,9 @@
 			</File>
 			<File
 				RelativePath="..\..\src\Game\Alliance.h">
+			</File>
+			<File
+				RelativePath="..\..\src\Game\Ammunition.h">
 			</File>
 			<File
 				RelativePath="..\..\src\Game\Animatic.h">
@@ -2122,6 +2131,9 @@
 			</File>
 			<File
 				RelativePath="..\..\src\Game\VolTweakDefs.h">
+			</File>
+			<File
+				RelativePath="..\..\src\Game\VolleyFire.h">
 			</File>
 			<File
 				RelativePath="..\..\src\Game\Volume.h">

--- a/Windows/prj/vc8_hwsdl.vcproj
+++ b/Windows/prj/vc8_hwsdl.vcproj
@@ -387,6 +387,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\Game\Ammunition.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\Game\Animatic.c"
 				>
 			</File>
@@ -1527,6 +1531,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\Game\VolleyFire.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\Game\Volume.c"
 				>
 			</File>
@@ -1757,6 +1765,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\Game\Alliance.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\Game\Ammunition.h"
 				>
 			</File>
 			<File
@@ -2761,6 +2773,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\Game\VolTweakDefs.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\Game\VolleyFire.h"
 				>
 			</File>
 			<File

--- a/src/Game/Ammunition.c
+++ b/src/Game/Ammunition.c
@@ -1,0 +1,119 @@
+//
+//  Ammunition.c
+//  Manages ammunition logic such as reloading behavior.
+//
+//  Created on 2020-12-21 by KajiTetsushi
+//  Copyleft HomeworldSDL.
+//
+
+#include "Ammunition.h"
+
+#include "SpaceObj.h"
+#include "StatScript.h"
+#include "Types.h"
+#include "Universe.h"
+
+static AmmunitionStat ammunitionStat;
+
+scriptStructEntry AmmunitionStatScriptTable[] =
+{
+    { "ammo.reloadDelay",    scriptSetReal32CB,    &(ammunitionStat.reloadDelay),    &ammunitionStat },
+
+    END_SCRIPT_STRUCT_ENTRY
+};
+
+bool findIndexOfLeastNoOfRoundsGun(GunInfo *gunInfo, GunStaticInfo *gunStaticInfo, AmmunitionSpec *spec, AmmunitionStat *stat);
+
+//#region Setters
+void ammunitionSetLastReloadedTimestamp(AmmunitionSpec *spec, real32 timestamp)
+{
+    spec->lastReloadedTimestamp = timestamp;
+}
+//#endregion
+
+/**
+ * @brief Initializes the ammunition manager.
+ * @param spec Ammunition instance.
+ */
+void ammunitionInit(AmmunitionSpec *spec)
+{
+    ammunitionSetLastReloadedTimestamp(spec, 0.0f);
+}
+
+/**
+ * @brief Reloads one weapon, i.e. the weapon with the least number of rounds, with one round of ammunition.
+ * @param spec Ammunition instance.
+ * @param stat Ammunition configuration.
+ * @param gunInfo Array of gun instances.
+ * @param gunStaticInfo Array of gun configurations.
+ */
+void ammunitionReloadLeastNoOfRoundsGun(
+    AmmunitionSpec *spec,
+    AmmunitionStat *stat,
+    GunInfo *gunInfo,
+    GunStaticInfo *gunStaticInfo)
+{
+    if ((universe.totaltimeelapsed - spec->lastReloadedTimestamp) <= stat->reloadDelay)
+    {
+        return;
+    }
+
+    spec->lastReloadedTimestamp = universe.totaltimeelapsed;
+
+    sdword leastNoOfRoundsGunIndex = findIndexOfLeastNoOfRoundsGun(gunInfo, gunStaticInfo, spec, stat);
+
+    if (leastNoOfRoundsGunIndex < 0)
+    {
+        return;
+    }
+
+    gunInfo->guns[leastNoOfRoundsGunIndex].numMissiles++;
+}
+
+bool findIndexOfLeastNoOfRoundsGun(
+    GunInfo *gunInfo,
+    GunStaticInfo *gunStaticInfo,
+    AmmunitionSpec *spec,
+    AmmunitionStat *stat)
+{
+    sdword noOfGuns = gunInfo->numGuns;
+    sdword gunIndex;
+    sdword leastNoOfRoundsGunIndex = -1; // Index of the gun with the least number of rounds.
+    sdword leastNoOfRounds = -1;         // Stores the eventual value of the least number of rounds through iteration.
+
+    Gun *gun;
+    GunStatic *gunStat;
+
+    for (gunIndex = 0; gunIndex < noOfGuns; gunIndex++)
+    {
+        gunStat = &gunStaticInfo->gunstatics[gunIndex];
+
+        // Stop here if the weapon doesn't have ammunition capacity as an attribute.
+        if (gunStat->maxMissiles == 0)
+        {
+            continue;
+        }
+
+        // Attempt to find the gun with the smallest number of rounds.
+        gun = &gunInfo->guns[gunIndex];
+
+        leastNoOfRounds = leastNoOfRounds <= 0
+            ? gunStat->maxMissiles
+            : leastNoOfRounds;
+
+        if (gun->numMissiles >= gunStat->maxMissiles)
+        {
+            continue;
+        }
+
+        if (gun->numMissiles >= leastNoOfRounds)
+        {
+            continue;
+        }
+
+        leastNoOfRounds = gun->numMissiles;
+        leastNoOfRoundsGunIndex = gunIndex;
+    }
+
+    return leastNoOfRoundsGunIndex;
+}

--- a/src/Game/Ammunition.h
+++ b/src/Game/Ammunition.h
@@ -1,0 +1,37 @@
+//
+//  Ammunition.h
+//  Manages ammunition logic such as reloading behavior.
+//
+//  Created on 2020-12-21 by KajiTetsushi
+//  Copyleft HomeworldSDL.
+//
+
+#ifndef ___AMMUNITION_H
+#define ___AMMUNITION_H
+
+#include "SpaceObj.h"
+#include "StatScript.h"
+#include "Types.h"
+
+typedef struct AmmunitionSpec
+{
+    /**
+     * The elapsed time (in seconds) since the last time the ammunition has been reloaded.
+     */
+    real32 lastReloadedTimestamp;
+} AmmunitionSpec;
+
+typedef struct AmmunitionStat
+{
+    /**
+     * The waiting duration (in seconds) before incrementing the ship's total ammunition by 1.
+     */
+    real32 reloadDelay;
+} AmmunitionStat;
+
+extern scriptStructEntry AmmunitionStatScriptTable[];
+
+void ammunitionInit(AmmunitionSpec *spec);
+void ammunitionReloadLeastNoOfRoundsGun(AmmunitionSpec *spec, AmmunitionStat *stat, GunInfo *gunInfo, GunStaticInfo *gunStaticInfo);
+
+#endif

--- a/src/Game/Select.c
+++ b/src/Game/Select.c
@@ -1227,7 +1227,6 @@ void selSelectionDraw5(Ship *ship)      // PLEASE DON'T COMMENT THIS FUNCTION OU
 
 /**
  * @brief Prints the ammunition counter if the ship has ammunition.
- * 
  * @param ship The reference ship.
  * @param font Font to use for the particular LOD.
  * @param x Coordinates to print on screen from the left.

--- a/src/Game/SpaceObj.h
+++ b/src/Game/SpaceObj.h
@@ -75,6 +75,9 @@ typedef struct
     // for GUN_MissileLauncher
     sdword maxMissiles;
 
+    // VolleyFire
+    bool canVolleyFire;         // Can the volley fire special ability use this weapon?
+
     real32 triggerHappy;        // cosine of maximum allowed angle allowed before a fixed gun will shoot
     real32 gunDamageLo[NUM_TACTICS_TYPES];          // low damage potential
     real32 gunDamageHi[NUM_TACTICS_TYPES];          // high damage potential

--- a/src/Game/SpaceObj.h
+++ b/src/Game/SpaceObj.h
@@ -592,6 +592,8 @@ typedef struct ShipStaticInfo
     bool8 canTargetMultipleTargets;
     bool8 rotateToRetaliate;
     bool8 canReceiveTheseShips[4];
+
+    bool8 canVolleyFire; // Indicates whether at least one of the ship's weapons uses the volley fire special ability.
     bool8 hasAmmunition; // Indicates whether at least one of the ship's weapons carry ammunition.
 
     bool passiveAttackPenaltyExempt;

--- a/src/Game/StatScript.c
+++ b/src/Game/StatScript.c
@@ -100,6 +100,7 @@ static scriptStructEntry StaticGunInfoScriptTable[] =
     { "DamageLo",            scriptSetReal32CB,       &(gunStaticTemplate.baseGunDamageLo),      &gunStaticTemplate },
     { "DamageHi",            scriptSetReal32CB,       &(gunStaticTemplate.baseGunDamageHi),      &gunStaticTemplate },
     { "MaxMissiles",         scriptSetSdwordCB,       &(gunStaticTemplate.maxMissiles),          &gunStaticTemplate },
+    { "canVolleyFire",       scriptSetBool8,          &(gunStaticTemplate.canVolleyFire),        &gunStaticTemplate },
     { "BulletLifeTime",      scriptSetReal32CB,       &(gunStaticTemplate.bulletlifetime),       &gunStaticTemplate },
     { "BulletLength",        scriptSetReal32CB,       &(gunStaticTemplate.bulletlength),         &gunStaticTemplate },
     { "BulletRange",         scriptSetReal32CB,       &(gunStaticTemplate.bulletrange),          &gunStaticTemplate },

--- a/src/Game/UnivUpdate.c
+++ b/src/Game/UnivUpdate.c
@@ -1487,19 +1487,12 @@ Ship *univCreateShip(ShipType shiptype,ShipRace shiprace,vector *shippos,struct 
             gun = &newship->gunInfo->guns[i];
             gunstatic = &shipstaticinfo->gunStaticInfo->gunstatics[i];
             gun->gunstatic = gunstatic;
-
+            gun->numMissiles = gunstatic->maxMissiles;
             switch (gunstatic->guntype)
             {
-                case GUN_MissileLauncher:
-                    gun->numMissiles = gunstatic->maxMissiles;
-                    // deliberately fall through
-                case GUN_MineLauncher:
-                    gun->numMissiles = gunstatic->maxMissiles;      //Use same var for mines
-                case GUN_Gimble:
                 case GUN_Fixed:
                     gun->gunheading = gunstatic->gunnormal;
                     break;
-
                 case GUN_NewGimble:
                     univResetNewGimbleGun(gun);
                     break;

--- a/src/Game/Universe.c
+++ b/src/Game/Universe.c
@@ -2253,8 +2253,9 @@ void InitStatShipInfo(ShipStaticInfo *statinfo,ShipType type,ShipRace race)
             gunstaticinfo->gunstatics[i].gunindex = i;
             gunstatic = &(statinfo)->gunStaticInfo->gunstatics[i];
 
-            // Precompute indication that this ship will carry ammunition.
+            // Precompute indicators.
             statinfo->hasAmmunition = statinfo->hasAmmunition || gunstatic->maxMissiles;
+            statinfo->canVolleyFire = statinfo->canVolleyFire || gunstatic->canVolleyFire;
         }
         mexGetGunStaticInfo(gunstaticinfo,statinfo->staticheader.pMexData);
     }

--- a/src/Game/VolleyFire.c
+++ b/src/Game/VolleyFire.c
@@ -1,0 +1,344 @@
+//
+//  VolleyFire.c
+//  Handles behavior involving the volley fire speciabl ability.
+//
+//  Created on 2020-12-13 by Kaji Tetsushi
+//  Copyleft HomeworldSDL.
+//
+
+#include "VolleyFire.h"
+
+#include "AIShip.h"
+#include "AITrack.h"
+#include "Battle.h"
+#include "Gun.h"
+#include "ShipSelect.h"
+#include "SoundEvent.h"
+#include "StatScript.h"
+#include "Universe.h"
+
+static VolleyFireStat volleyFireStat;
+
+scriptStructEntry VolleyFireStatScriptTable[] =
+{
+
+    { "volleyFire.fireDelay",          scriptSetReal32CB,    &(volleyFireStat.fireDelay),          &volleyFireStat },
+    { "volleyFire.abilityCooldown",    scriptSetReal32CB,    &(volleyFireStat.abilityCooldown),    &volleyFireStat },
+
+    END_SCRIPT_STRUCT_ENTRY
+};
+
+//#region Setters
+void volleyFireSetCurrentTargetIndex(VolleyFireSpec *spec, sdword index)
+{
+    spec->currentTargetIndex = index;
+}
+
+void volleyFireSetBattleChatterBusy(VolleyFireSpec *spec, bool busy)
+{
+    spec->battleChatterBusy = busy;
+}
+
+void volleyFireSetLastAttemptedTimestamp(VolleyFireSpec *spec, real32 timestamp)
+{
+    spec->lastAttemptedOn = timestamp;
+}
+
+void volleyFireSetLastActivatedTimestamp(VolleyFireSpec *spec, real32 timestamp)
+{
+    spec->lastActivatedOn = timestamp;
+}
+//#endregion
+
+sdword volleyFireGetNextTargetIndex(sdword currentTargetIndex, sdword noOfTargets)
+{
+    sdword nextTargetIndex = currentTargetIndex + 1;
+
+    return nextTargetIndex < noOfTargets ? nextTargetIndex : 0;
+}
+
+void volleyFireBattleChatterAttempt(Ship *ship, sdword event)
+{
+    if (ship->playerowner->playerIndex == universe.curPlayerIndex)
+    {
+        if (battleCanChatterAtThisTime(event, ship))
+        {
+            battleChatterAttempt(SOUND_EVENT_DEFAULT, event, ship, SOUND_EVENT_DEFAULT);
+        }
+    }
+}
+
+/**
+ * @brief Determines if the ship's volley fire special ability is still in cooldown.
+ * @param ship Volley fire instance.
+ * @return TRUE if still in cooldown, FALSE if free from cooldown.
+ */
+bool volleyFireIsReady(VolleyFireSpec *spec, VolleyFireStat *stat)
+{
+    real32 durationSinceLastAttempted = universe.totaltimeelapsed - spec->lastAttemptedOn;
+
+    return durationSinceLastAttempted > stat->abilityCooldown;
+}
+
+/**
+ * @brief Initializes the volley fire special ability.
+ * @param spec Volley fire instance.
+ */
+void volleyFireInit(VolleyFireSpec *spec)
+{
+    volleyFireSetCurrentTargetIndex(spec, 0);
+    volleyFireSetBattleChatterBusy(spec, FALSE);
+    volleyFireSetLastAttemptedTimestamp(spec, -100000.0f);
+    volleyFireSetLastActivatedTimestamp(spec, 0.0f);
+}
+
+/**
+ * @brief Invokes the volley fire special ability with a user-defined weapons behavior.
+ * @param ship Ship reference.
+ * @param custom Targets selected to attack.
+ * @param spec Volley fire instance.
+ * @param stat Volley fire configuration.
+ * @param shootTargets Ship behavior to use when attacking all selected targets.
+ * @param shoot Weapon behavior to use to shoot each target at least once.
+ * @param battleChatter Battle chatter event to use when the ability has been activated.
+ * @return Indication of whether the ship's volley fire sequence is complete.
+ */
+bool volleyFireSpecialTarget(
+    Ship *ship,                        // Ship.
+    void *custom,                      // Targets selected to attack.
+    VolleyFireSpec *spec,              // Volley fire instance.
+    VolleyFireStat *stat,              // Volley fire configuration.
+    ShootTargetsCallback shootTargets, // Ship behavior to use when attacking all selected targets.
+    ShootCallback shoot,               // Weapon behavior to use to shoot each target at least once.
+    sdword battleChatterEvent)         // Battle chatter event to use when the ability has been activated.
+{
+    // Stop here if the user-defined callbacks aren't provided, since the volley fire won't work, anyway.
+    if (shootTargets == NULL || shoot == NULL)
+    {
+        return TRUE;
+    }
+
+    volleyFireSetLastAttemptedTimestamp(spec, universe.totaltimeelapsed);
+
+    // Stop here if the "volley reload time" has passed
+    if ((universe.totaltimeelapsed - spec->lastActivatedOn) <= stat->fireDelay)
+    {
+        return FALSE;
+    }
+
+    volleyFireSetLastActivatedTimestamp(spec, universe.totaltimeelapsed);
+
+    SpaceObjRotImpTarg *target;
+    SelectAnyCommand *targets = (SelectAnyCommand *)custom;
+    sdword noOfShipsToTarget = targets->numTargets;
+
+    // Stop here and reset everything if no target was selected.
+    if (noOfShipsToTarget == 0)
+    {
+        volleyFireSetBattleChatterBusy(spec, FALSE);
+        volleyFireSetCurrentTargetIndex(spec, 0);
+
+        return TRUE;
+    }
+
+    // Attempt voice feedback if the ship's not busy.
+    if (!(spec->battleChatterBusy))
+    {
+        volleyFireSetBattleChatterBusy(spec, TRUE);
+
+        if (battleChatterEvent != NULL)
+        {
+            volleyFireBattleChatterAttempt(ship, battleChatterEvent);
+        }
+    }
+
+    return shootTargets(ship, spec, targets, shoot);
+}
+
+/**
+ * @brief Sets the ship to volley fire without changing its velocity. Use for ships with hit-and-run capabilities such as fighters and corvettes.
+ * @param ship Ship.
+ * @param spec Volley fire instance.
+ * @param targets All targets selected when the volley fire special ability as activated.
+ * @param shoot Weapon behavior to use to shoot each target at least once.
+ * @return Indication of whether the ship's volley fire sequence is complete.
+ */
+bool volleyFireShootAllTargetsDrifting(
+    Ship *ship,                // Ship.
+    VolleyFireSpec *spec,      // Volley fire instance.
+    SelectAnyCommand *targets, // All targets selected when the volley fire special ability as activated.
+    ShootCallback shoot)       // Weapon behavior to use to shoot each target at least once.
+{
+    // Stop here if the shoot callback isn't provided, since the volley fire won't work, anyway.
+    if (shoot == NULL)
+    {
+        return TRUE;
+    }
+
+    ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
+
+    // Targets
+    SpaceObjRotImpTarg *target;
+    sdword noOfShipsToTarget = targets->numTargets;
+
+    // Weapons
+    Gun *gun;
+    GunStatic *gunStatic;
+    sdword gunIndex;
+    sdword noOfGuns = ship->gunInfo->numGuns;
+    bool hasFiredAtLeastOnce = FALSE;
+
+    // Correct the current target index if it's out of bounds from the last attempt.
+    if (spec->currentTargetIndex >= noOfShipsToTarget)
+    {
+        volleyFireSetCurrentTargetIndex(spec, 0);
+    }
+
+    // Attempt to attack each target.
+    for (gunIndex = 0; gunIndex < noOfGuns; gunIndex++)
+    {
+        target = targets->TargetPtr[spec->currentTargetIndex];
+        gunStatic = &shipStaticInfo->gunStaticInfo->gunstatics[gunIndex];
+        gun = &ship->gunInfo->guns[gunIndex];
+
+        // Break early if this weapon cannot volley fire.
+        if (!(gunStatic->canVolleyFire))
+        {
+            continue;
+        }
+
+        // Break early if this weapon has no ammunition remaining.
+        if (!gunHasAmmunition(gun))
+        {
+            continue;
+        }
+
+        hasFiredAtLeastOnce = TRUE;
+        shoot(ship, gun, target);
+
+        sdword nextTargetIndex = volleyFireGetNextTargetIndex(spec->currentTargetIndex, noOfShipsToTarget);
+        volleyFireSetCurrentTargetIndex(spec, nextTargetIndex);
+    }
+
+    if (hasFiredAtLeastOnce)
+    {
+        return FALSE;
+    }
+    // Stop here and reset everything if the weapons are out of ammunition.
+    else
+    {
+        volleyFireSetBattleChatterBusy(spec, FALSE);
+        volleyFireSetCurrentTargetIndex(spec, 0);
+
+        return TRUE;
+    }
+}
+
+/**
+ * @brief Sets the ship to volley fire in place, flying towards its first target if necessary. Use for slow ships such as frigates and capital ships.
+ * @param ship Ship.
+ * @param spec Volley fire instance.
+ * @param targets All targets selected when the volley fire special ability as activated.
+ * @param shoot Weapon behavior to use to shoot each target at least once.
+ * @return Indication of whether the ship's volley fire sequence is complete.
+ */
+bool volleyFireShootAllTargetsLumbering(
+    Ship *ship,                // Ship.
+    VolleyFireSpec *spec,      // Volley fire instance.
+    SelectAnyCommand *targets, // All targets selected when the volley fire special ability as activated.
+    ShootCallback shoot)       // Weapon behavior to use to shoot each target at least once.
+{
+    // Stop here if the shoot callback isn't provided, since the volley fire won't work, anyway.
+    if (shoot == NULL)
+    {
+        return TRUE;
+    }
+
+    ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
+
+    // Targets
+    SpaceObjRotImpTarg *target;
+    sdword noOfShipsToTarget = targets->numTargets;
+
+    // Weapons
+    Gun *gun;
+    GunStatic *gunStatic;
+    sdword gunIndex;
+    sdword noOfGuns = ship->gunInfo->numGuns;
+    bool hasFiredAtLeastOnce = FALSE;
+    bool hasAttemptedToFireAtLeastOnce = FALSE;
+
+    // Ranging
+    vector trajectory;
+    real32 rangeToTarget;
+    real32 maxRangeToTarget;
+
+    // Correct the current target index if it's out of bounds from the last attempt.
+    if (spec->currentTargetIndex >= noOfShipsToTarget)
+    {
+        volleyFireSetCurrentTargetIndex(spec, 0);
+    }
+
+    // Attempt to attack each target.
+    for (gunIndex = 0; gunIndex < noOfGuns; gunIndex++)
+    {
+        target = targets->TargetPtr[spec->currentTargetIndex];
+        gunStatic = &shipStaticInfo->gunStaticInfo->gunstatics[gunIndex];
+        gun = &ship->gunInfo->guns[gunIndex];
+
+        // Break early if this weapon cannot volley fire.
+        if (!(gunStatic->canVolleyFire))
+        {
+            continue;
+        }
+
+        // Calculate range to target.
+        vecSub(trajectory, ship->collInfo.collPosition, target->collInfo.collPosition);
+        rangeToTarget = RangeToTarget(ship, target, &trajectory);
+        maxRangeToTarget = gun->gunstatic->bulletrange * 0.9f;
+
+        // Break early if this weapon is out of range to target.
+        if (rangeToTarget >= maxRangeToTarget)
+        {
+            continue;
+        }
+
+        hasAttemptedToFireAtLeastOnce = TRUE;
+
+        // Break early if this weapon has no ammunition remaining.
+        if (!gunHasAmmunition(gun))
+        {
+            continue;
+        }
+
+        hasFiredAtLeastOnce = TRUE;
+        shoot(ship, gun, target);
+
+        sdword nextTargetIndex = volleyFireGetNextTargetIndex(spec->currentTargetIndex, noOfShipsToTarget);
+        volleyFireSetCurrentTargetIndex(spec, nextTargetIndex);
+    }
+
+    if (hasFiredAtLeastOnce)
+    {
+        aitrackZeroVelocity(ship);
+        return FALSE;
+    }
+    // Stop here and reset everything if the weapons are out of ammunition.
+    else if (hasAttemptedToFireAtLeastOnce)
+    {
+        volleyFireSetBattleChatterBusy(spec, FALSE);
+        volleyFireSetCurrentTargetIndex(spec, 0);
+
+        return TRUE;
+    }
+    // Stop here and attempt to approach first target in the selection list.
+    else
+    {
+        Ship *nextTarget = (Ship *)targets->TargetPtr[0];
+        udword aishipFlags = AISHIP_FastAsPossible | AISHIP_PointInDirectionFlying;
+        real32 limitVelocity = 0.0f;
+        aishipFlyToShipAvoidingObjs(ship, nextTarget, aishipFlags, limitVelocity);
+    
+        return FALSE;
+    }
+}

--- a/src/Game/VolleyFire.c
+++ b/src/Game/VolleyFire.c
@@ -8,8 +8,6 @@
 
 #include "VolleyFire.h"
 
-#include "AIShip.h"
-#include "AITrack.h"
 #include "Battle.h"
 #include "Gun.h"
 #include "ShipSelect.h"
@@ -86,8 +84,8 @@ bool volleyFireIsReady(VolleyFireSpec *spec, VolleyFireStat *stat)
  */
 void volleyFireInit(VolleyFireSpec *spec)
 {
-    volleyFireSetCurrentTargetIndex(spec, 0);
     volleyFireSetBattleChatterBusy(spec, FALSE);
+    volleyFireSetCurrentTargetIndex(spec, 0);
     volleyFireSetLastAttemptedTimestamp(spec, -100000.0f);
     volleyFireSetLastActivatedTimestamp(spec, 0.0f);
 }
@@ -98,42 +96,32 @@ void volleyFireInit(VolleyFireSpec *spec)
  * @param custom Targets selected to attack.
  * @param spec Volley fire instance.
  * @param stat Volley fire configuration.
- * @param shootTargets Ship behavior to use when attacking all selected targets.
- * @param shoot Weapon behavior to use to shoot each target at least once.
  * @param battleChatter Battle chatter event to use when the ability has been activated.
+ * @param attackTargets Ship behavior to use when attacking all selected targets.
  * @return Indication of whether the ship's volley fire sequence is complete.
  */
 bool volleyFireSpecialTarget(
-    Ship *ship,                        // Ship.
-    void *custom,                      // Targets selected to attack.
-    VolleyFireSpec *spec,              // Volley fire instance.
-    VolleyFireStat *stat,              // Volley fire configuration.
-    ShootTargetsCallback shootTargets, // Ship behavior to use when attacking all selected targets.
-    ShootCallback shoot,               // Weapon behavior to use to shoot each target at least once.
-    sdword battleChatterEvent)         // Battle chatter event to use when the ability has been activated.
+    Ship *ship,                          // Ship.
+    SelectAnyCommand *targets,           // Targets selected to attack.
+    VolleyFireSpec *spec,                // Volley fire instance.
+    VolleyFireStat *stat,                // Volley fire configuration.
+    sdword battleChatterEvent,           // Battle chatter event to use when the ability has been activated.
+    AttackTargetsCallback attackTargets) // Ship behavior to use when attacking all selected targets.
 {
-    // Stop here if the user-defined callbacks aren't provided, since the volley fire won't work, anyway.
-    if (shootTargets == NULL || shoot == NULL)
-    {
-        return TRUE;
-    }
+    dbgAssertOrIgnore(attackTargets != NULL);
 
     volleyFireSetLastAttemptedTimestamp(spec, universe.totaltimeelapsed);
 
     // Stop here if the "volley reload time" has passed
-    if ((universe.totaltimeelapsed - spec->lastActivatedOn) <= stat->fireDelay)
+    real32 durationSinceLastActivated = universe.totaltimeelapsed - spec->lastActivatedOn;
+    if (durationSinceLastActivated <= stat->fireDelay)
     {
         return FALSE;
     }
 
     volleyFireSetLastActivatedTimestamp(spec, universe.totaltimeelapsed);
 
-    SpaceObjRotImpTarg *target;
-    SelectAnyCommand *targets = (SelectAnyCommand *)custom;
-    sdword noOfShipsToTarget = targets->numTargets;
-
-    // Stop here and reset everything if no target was selected.
-    if (noOfShipsToTarget == 0)
+    if (targets->numTargets == 0)
     {
         volleyFireSetBattleChatterBusy(spec, FALSE);
         volleyFireSetCurrentTargetIndex(spec, 0);
@@ -152,193 +140,5 @@ bool volleyFireSpecialTarget(
         }
     }
 
-    return shootTargets(ship, spec, targets, shoot);
-}
-
-/**
- * @brief Sets the ship to volley fire without changing its velocity. Use for ships with hit-and-run capabilities such as fighters and corvettes.
- * @param ship Ship.
- * @param spec Volley fire instance.
- * @param targets All targets selected when the volley fire special ability as activated.
- * @param shoot Weapon behavior to use to shoot each target at least once.
- * @return Indication of whether the ship's volley fire sequence is complete.
- */
-bool volleyFireShootAllTargetsDrifting(
-    Ship *ship,                // Ship.
-    VolleyFireSpec *spec,      // Volley fire instance.
-    SelectAnyCommand *targets, // All targets selected when the volley fire special ability as activated.
-    ShootCallback shoot)       // Weapon behavior to use to shoot each target at least once.
-{
-    // Stop here if the shoot callback isn't provided, since the volley fire won't work, anyway.
-    if (shoot == NULL)
-    {
-        return TRUE;
-    }
-
-    ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
-
-    // Targets
-    SpaceObjRotImpTarg *target;
-    sdword noOfShipsToTarget = targets->numTargets;
-
-    // Weapons
-    Gun *gun;
-    GunStatic *gunStatic;
-    sdword gunIndex;
-    sdword noOfGuns = ship->gunInfo->numGuns;
-    bool hasFiredAtLeastOnce = FALSE;
-
-    // Correct the current target index if it's out of bounds from the last attempt.
-    if (spec->currentTargetIndex >= noOfShipsToTarget)
-    {
-        volleyFireSetCurrentTargetIndex(spec, 0);
-    }
-
-    // Attempt to attack each target.
-    for (gunIndex = 0; gunIndex < noOfGuns; gunIndex++)
-    {
-        target = targets->TargetPtr[spec->currentTargetIndex];
-        gunStatic = &shipStaticInfo->gunStaticInfo->gunstatics[gunIndex];
-        gun = &ship->gunInfo->guns[gunIndex];
-
-        // Break early if this weapon cannot volley fire.
-        if (!(gunStatic->canVolleyFire))
-        {
-            continue;
-        }
-
-        // Break early if this weapon has no ammunition remaining.
-        if (!gunHasAmmunition(gun))
-        {
-            continue;
-        }
-
-        hasFiredAtLeastOnce = TRUE;
-        shoot(ship, gun, target);
-
-        sdword nextTargetIndex = volleyFireGetNextTargetIndex(spec->currentTargetIndex, noOfShipsToTarget);
-        volleyFireSetCurrentTargetIndex(spec, nextTargetIndex);
-    }
-
-    if (hasFiredAtLeastOnce)
-    {
-        return FALSE;
-    }
-    // Stop here and reset everything if the weapons are out of ammunition.
-    else
-    {
-        volleyFireSetBattleChatterBusy(spec, FALSE);
-        volleyFireSetCurrentTargetIndex(spec, 0);
-
-        return TRUE;
-    }
-}
-
-/**
- * @brief Sets the ship to volley fire in place, flying towards its first target if necessary. Use for slow ships such as frigates and capital ships.
- * @param ship Ship.
- * @param spec Volley fire instance.
- * @param targets All targets selected when the volley fire special ability as activated.
- * @param shoot Weapon behavior to use to shoot each target at least once.
- * @return Indication of whether the ship's volley fire sequence is complete.
- */
-bool volleyFireShootAllTargetsLumbering(
-    Ship *ship,                // Ship.
-    VolleyFireSpec *spec,      // Volley fire instance.
-    SelectAnyCommand *targets, // All targets selected when the volley fire special ability as activated.
-    ShootCallback shoot)       // Weapon behavior to use to shoot each target at least once.
-{
-    // Stop here if the shoot callback isn't provided, since the volley fire won't work, anyway.
-    if (shoot == NULL)
-    {
-        return TRUE;
-    }
-
-    ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
-
-    // Targets
-    SpaceObjRotImpTarg *target;
-    sdword noOfShipsToTarget = targets->numTargets;
-
-    // Weapons
-    Gun *gun;
-    GunStatic *gunStatic;
-    sdword gunIndex;
-    sdword noOfGuns = ship->gunInfo->numGuns;
-    bool hasFiredAtLeastOnce = FALSE;
-    bool hasAttemptedToFireAtLeastOnce = FALSE;
-
-    // Ranging
-    vector trajectory;
-    real32 rangeToTarget;
-    real32 maxRangeToTarget;
-
-    // Correct the current target index if it's out of bounds from the last attempt.
-    if (spec->currentTargetIndex >= noOfShipsToTarget)
-    {
-        volleyFireSetCurrentTargetIndex(spec, 0);
-    }
-
-    // Attempt to attack each target.
-    for (gunIndex = 0; gunIndex < noOfGuns; gunIndex++)
-    {
-        target = targets->TargetPtr[spec->currentTargetIndex];
-        gunStatic = &shipStaticInfo->gunStaticInfo->gunstatics[gunIndex];
-        gun = &ship->gunInfo->guns[gunIndex];
-
-        // Break early if this weapon cannot volley fire.
-        if (!(gunStatic->canVolleyFire))
-        {
-            continue;
-        }
-
-        // Calculate range to target.
-        vecSub(trajectory, ship->collInfo.collPosition, target->collInfo.collPosition);
-        rangeToTarget = RangeToTarget(ship, target, &trajectory);
-        maxRangeToTarget = gun->gunstatic->bulletrange * 0.9f;
-
-        // Break early if this weapon is out of range to target.
-        if (rangeToTarget >= maxRangeToTarget)
-        {
-            continue;
-        }
-
-        hasAttemptedToFireAtLeastOnce = TRUE;
-
-        // Break early if this weapon has no ammunition remaining.
-        if (!gunHasAmmunition(gun))
-        {
-            continue;
-        }
-
-        hasFiredAtLeastOnce = TRUE;
-        shoot(ship, gun, target);
-
-        sdword nextTargetIndex = volleyFireGetNextTargetIndex(spec->currentTargetIndex, noOfShipsToTarget);
-        volleyFireSetCurrentTargetIndex(spec, nextTargetIndex);
-    }
-
-    if (hasFiredAtLeastOnce)
-    {
-        aitrackZeroVelocity(ship);
-        return FALSE;
-    }
-    // Stop here and reset everything if the weapons are out of ammunition.
-    else if (hasAttemptedToFireAtLeastOnce)
-    {
-        volleyFireSetBattleChatterBusy(spec, FALSE);
-        volleyFireSetCurrentTargetIndex(spec, 0);
-
-        return TRUE;
-    }
-    // Stop here and attempt to approach first target in the selection list.
-    else
-    {
-        Ship *nextTarget = (Ship *)targets->TargetPtr[0];
-        udword aishipFlags = AISHIP_FastAsPossible | AISHIP_PointInDirectionFlying;
-        real32 limitVelocity = 0.0f;
-        aishipFlyToShipAvoidingObjs(ship, nextTarget, aishipFlags, limitVelocity);
-    
-        return FALSE;
-    }
+    return attackTargets(ship, spec, stat, targets);
 }

--- a/src/Game/VolleyFire.h
+++ b/src/Game/VolleyFire.h
@@ -1,0 +1,49 @@
+//
+//  VolleyFire.h
+//
+//  Created on 2020-12-13 by Kaji Tetsushi
+//  Copyleft HomeworldSDL.
+//
+
+#ifndef ___VOLLEYFIRE_H
+#define ___VOLLEYFIRE_H
+
+#include "ShipSelect.h"
+#include "SpaceObj.h"
+#include "StatScript.h"
+#include "Types.h"
+
+typedef struct VolleyFireSpec
+{
+    real32 lastAttemptedOn;
+    real32 lastActivatedOn;
+    sdword currentTargetIndex;
+    bool battleChatterBusy;
+} VolleyFireSpec;
+
+typedef struct VolleyFireStat
+{
+    /**
+     * The delay (in seconds) between every weapon fire while the volley fire special ability is active.
+     */
+    real32 fireDelay;
+    /**
+     * The delay (in seconds) before the volley fire special ability can be used again after its last activation.
+     */
+    real32 abilityCooldown;
+} VolleyFireStat;
+
+extern scriptStructEntry VolleyFireStatScriptTable[];
+
+typedef void (*ShootCallback)(Ship *ship, Gun *gun, SpaceObjRotImpTarg *target);
+typedef bool (*ShootTargetsCallback)(struct Ship *ship, VolleyFireSpec *spec, SelectAnyCommand *targets, ShootCallback shoot);
+
+void volleyFireInit(VolleyFireSpec *spec);
+bool volleyFireIsReady(VolleyFireSpec *spec, VolleyFireStat *stat);
+
+bool volleyFireShootAllTargetsDrifting(Ship *ship, VolleyFireSpec *spec, SelectAnyCommand *targets, ShootCallback shoot);
+bool volleyFireShootAllTargetsLumbering(Ship *ship, VolleyFireSpec *spec, SelectAnyCommand *targets, ShootCallback shoot);
+
+bool volleyFireSpecialTarget(Ship *ship, void *custom, VolleyFireSpec *spec, VolleyFireStat *stat, ShootTargetsCallback shootTargets, ShootCallback shoot, sdword battleChatterEvent);
+
+#endif

--- a/src/Game/VolleyFire.h
+++ b/src/Game/VolleyFire.h
@@ -9,7 +9,6 @@
 #define ___VOLLEYFIRE_H
 
 #include "ShipSelect.h"
-#include "SpaceObj.h"
 #include "StatScript.h"
 #include "Types.h"
 
@@ -35,15 +34,15 @@ typedef struct VolleyFireStat
 
 extern scriptStructEntry VolleyFireStatScriptTable[];
 
-typedef void (*ShootCallback)(Ship *ship, Gun *gun, SpaceObjRotImpTarg *target);
-typedef bool (*ShootTargetsCallback)(struct Ship *ship, VolleyFireSpec *spec, SelectAnyCommand *targets, ShootCallback shoot);
+typedef bool (*AttackTargetsCallback)(struct Ship *ship, VolleyFireSpec *spec, VolleyFireStat *stat, SelectAnyCommand *targets);
 
+void volleyFireSetCurrentTargetIndex(VolleyFireSpec *spec, sdword index);
+void volleyFireSetBattleChatterBusy(VolleyFireSpec *spec, bool busy);
+void volleyFireSetLastAttemptedTimestamp(VolleyFireSpec *spec, real32 timestamp);
+void volleyFireSetLastActivatedTimestamp(VolleyFireSpec *spec, real32 timestamp);
+sdword volleyFireGetNextTargetIndex(sdword currentTargetIndex, sdword noOfTargets);
 void volleyFireInit(VolleyFireSpec *spec);
 bool volleyFireIsReady(VolleyFireSpec *spec, VolleyFireStat *stat);
-
-bool volleyFireShootAllTargetsDrifting(Ship *ship, VolleyFireSpec *spec, SelectAnyCommand *targets, ShootCallback shoot);
-bool volleyFireShootAllTargetsLumbering(Ship *ship, VolleyFireSpec *spec, SelectAnyCommand *targets, ShootCallback shoot);
-
-bool volleyFireSpecialTarget(Ship *ship, void *custom, VolleyFireSpec *spec, VolleyFireStat *stat, ShootTargetsCallback shootTargets, ShootCallback shoot, sdword battleChatterEvent);
+bool volleyFireSpecialTarget(Ship *ship, SelectAnyCommand *targets, VolleyFireSpec *spec, VolleyFireStat *stat, sdword battleChatterEvent, AttackTargetsCallback attackTargets);
 
 #endif

--- a/src/SDL/mouse.c
+++ b/src/SDL/mouse.c
@@ -1327,12 +1327,16 @@ void mouseSelectCursorSetting(void)
             {
                 bitSet(mouseInfo.flags, MCF_NonCombat);
             }
+
+            if (ship->staticinfo->canVolleyFire)
+            {
+                bitSet(mouseInfo.flags, MCF_SpecialAttack);
+            }
+
             //set flags for special attack/support ships
             switch (ship->shiptype)
             {
-                case MissileDestroyer:
                 case HeavyCorvette:
-                case P1MissileCorvette:
                     bitSet(mouseInfo.flags, MCF_SpecialAttack);
                     break;
                 case Carrier:

--- a/src/Ships/MinelayerCorvette.c
+++ b/src/Ships/MinelayerCorvette.c
@@ -51,6 +51,9 @@ real32 mothershipDistSqr2;
 
 #define DIST_FROM_HALL_BREAKPOS     600
 
+/**
+ * @deprecated We should use the new namespaced API from here on out.
+ */
 scriptStructEntry MinelayerCorvetteStaticScriptTable[] =
 {
     { "NumMinesInSide",    scriptSetUdwordCB,  &(MinelayerCorvetteStatic.NumMinesInSide),  &(MinelayerCorvetteStatic) },
@@ -84,6 +87,21 @@ scriptStructEntry MinelayerCorvetteStaticScriptTable[] =
 
 bool MinelayerCorvetteStaticMineDrop(Ship *ship,SpaceObjRotImpTarg *target);
 
+/**
+ * @brief Initializes the ship using legacy attributes, if all of them were provided.
+ * @deprecated Backwards compatibility
+ * @param shipStaticInfo Ship static info.
+ * @param stat Ship statics.
+ */
+void MinelayerCorvetteStaticInitLegacy(struct ShipStaticInfo *shipStaticInfo, MinelayerCorvetteStatics *stat)
+{
+    if (!(stat->mineRegenerateTime))
+    {
+        return;
+    }
+
+    stat->ammunition.reloadDelay = stat->mineRegenerateTime;
+}
 
 void MinelayerCorvetteStaticInit(char *directory,char *filename,struct ShipStaticInfo *statinfo)
 {
@@ -94,7 +112,11 @@ void MinelayerCorvetteStaticInit(char *directory,char *filename,struct ShipStati
 
     statinfo->custstatinfo = corvstat;
 
-    scriptSetStruct(directory,filename,MinelayerCorvetteStaticScriptTable,(ubyte *)corvstat);
+    scriptSetStruct(directory, filename, AmmunitionStatScriptTable, (ubyte *)&corvstat->ammunition);
+    scriptSetStruct(directory, filename, MinelayerCorvetteStaticScriptTable, (ubyte *)corvstat);
+
+    MinelayerCorvetteStaticInitLegacy(statinfo, corvstat);
+
     corvstat->DropStopRadiusSqr = corvstat->MineDropDistance * corvstat->MineDropDistance;
     corvstat->NumMinesInSideSqr = corvstat->NumMinesInSide*corvstat->NumMinesInSide;
     corvstat->MineClearDistanceSQR = corvstat->MineClearDistance*corvstat->MineClearDistance;
@@ -655,44 +677,17 @@ void MineLayerCorvetteDied(Ship *ship)
 ----------------------------------------------------------------------------*/
 void MinelayerCorvetteHousekeep(Ship *ship)
 {
-    ShipStaticInfo *shipstaticinfo = (ShipStaticInfo *)ship->staticinfo;
+    ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
     MinelayerCorvetteSpec *spec = (MinelayerCorvetteSpec *)ship->ShipSpecifics;
-    MinelayerCorvetteStatics *mstat = (MinelayerCorvetteStatics *)shipstaticinfo->custstatinfo;
-    sdword numGuns;
-    sdword i;
-    Gun *gun;
-    GunStatic *gunstatic;
-    sdword minMissiles;
-    sdword minIndex;
+    MinelayerCorvetteStatics *stat = (MinelayerCorvetteStatics *)shipStaticInfo->custstatinfo;
+    GunInfo *gunInfo = ship->gunInfo;
+    GunStaticInfo *gunStaticInfo = shipStaticInfo->gunStaticInfo;
 
-    if ((universe.totaltimeelapsed - spec->lasttimeRegeneratedMines) > mstat->mineRegenerateTime)
-    {
-        spec->lasttimeRegeneratedMines = universe.totaltimeelapsed;
-        numGuns = ship->gunInfo->numGuns;
-
-        // find missile launcher with least missiles, and give it a missile
-        for (i=0,minIndex=-1,minMissiles=100000;i<numGuns;i++)
-        {
-            gunstatic = &shipstaticinfo->gunStaticInfo->gunstatics[i];
-            if (gunstatic->guntype == GUN_MineLauncher)
-            {
-                gun = &ship->gunInfo->guns[i];
-                if (gun->numMissiles < gunstatic->maxMissiles)
-                {
-                    if (gun->numMissiles < minMissiles)
-                    {
-                        minMissiles = gun->numMissiles;
-                        minIndex = i;
-                    }
-                }
-            }
-        }
-
-        if (minIndex != -1)
-        {
-            ship->gunInfo->guns[minIndex].numMissiles++;
-        }
-    }
+    ammunitionReloadLeastNoOfRoundsGun(
+        &spec->ammunition,
+        &stat->ammunition,
+        gunInfo,
+        gunStaticInfo);
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/Ships/MinelayerCorvette.h
+++ b/src/Ships/MinelayerCorvette.h
@@ -8,6 +8,7 @@
 #ifndef ___MINELAYERCORVETTE_H
 #define ___MINELAYERCORVETTE_H
 
+#include "Ammunition.h"
 #include "Attack.h"
 
 #define MINE_DROP_ATTACK            0
@@ -19,6 +20,8 @@
 typedef struct
 {
     AttackSideStepParameters sidestepParameters;
+    AmmunitionStat ammunition;
+
     udword NumMinesInSide;
     real32 MINE_STOP_FRICTION;
     real32 MineSpacing;
@@ -37,12 +40,18 @@ typedef struct
     real32 forced_drop_damage_lo;
     real32 gunReFireTime;
     real32 forced_drop_lifetime;
+
+    /**
+     * The waiting duration (in seconds) before incrementing the ship's total ammunition by 1.
+     * @deprecated Use ammunition.reloadDelay
+     */
     real32 mineRegenerateTime;
 } MinelayerCorvetteStatics;
 
 typedef struct
 {
     AttackSideStep attacksidestep;
+    AmmunitionSpec ammunition;
     sdword MiningStatus;
     udword dropcount;
     vector aivec;

--- a/src/Ships/MissileDestroyer.c
+++ b/src/Ships/MissileDestroyer.c
@@ -53,6 +53,7 @@ void MissileDestroyerStatInitLegacy(struct ShipStaticInfo *shipStaticInfo, Missi
     }
 
     // Assign fallbacks for the essential simple values.
+    shipStaticInfo->canVolleyFire = TRUE;
     stat->volleyFire.fireDelay = stat->missileVolleyTime;
     stat->volleyFire.abilityCooldown = stat->missileLagVolleyTime;
     stat->ammunition.reloadDelay = stat->missileRegenerateTime;

--- a/src/Ships/MissileDestroyer.c
+++ b/src/Ships/MissileDestroyer.c
@@ -7,63 +7,86 @@
 
 #include "MissileDestroyer.h"
 
-#include "AIShip.h"
-#include "AITrack.h"
+#include "Ammunition.h"
 #include "Attack.h"
-#include "Battle.h"
 #include "Collision.h"
+#include "Battle.h"
 #include "DefaultShip.h"
 #include "Gun.h"
+#include "ObjTypes.h"
 #include "SoundEvent.h"
 #include "StatScript.h"
 #include "Universe.h"
+#include "Vector.h"
+#include "VolleyFire.h"
 
-#define VOLLEY_BEGIN        10
-#define VOLLEY_NOT_BEGIN    20
+MissileDestroyerStat r1MissileDestroyerStat;
+MissileDestroyerStat r2MissileDestroyerStat;
 
-typedef struct
-{
-    real32 lasttimeRegeneratedMissiles;
-    real32 lasttimeFiredVolley;
-    real32 lasttimeDidSpecialTargeting;
-    sdword curTargetIndex;
-    sdword volleyState;
-} MissileDestroyerSpec;
-
-typedef struct
-{
-    real32 missiledestroyerGunRange[NUM_TACTICS_TYPES];
-    real32 missiledestroyerTooCloseRange[NUM_TACTICS_TYPES];
-    real32 missileRegenerateTime;
-    real32 missileVolleyTime;
-    real32 missileLagVolleyTime;
-} MissileDestroyerStatics;
-
-MissileDestroyerStatics MissileDestroyerStaticRace1;
-MissileDestroyerStatics MissileDestroyerStaticRace2;
-
+/**
+ * @deprecated We should use the new namespaced API from here on out.
+ */
 scriptStructEntry MissileDestroyerScriptTable[] =
 {
-    { "MissileRegenerateTime",scriptSetReal32CB, &(MissileDestroyerStaticRace1.missileRegenerateTime), &(MissileDestroyerStaticRace1) },
-    { "MissileVolleyTime",scriptSetReal32CB, &(MissileDestroyerStaticRace1.missileVolleyTime), &(MissileDestroyerStaticRace1) },
-    { "MissileLagVolleyTime",scriptSetReal32CB, &(MissileDestroyerStaticRace1.missileLagVolleyTime), &(MissileDestroyerStaticRace1) },
+    { "MissileRegenerateTime",    scriptSetReal32CB,    &(r1MissileDestroyerStat.missileRegenerateTime),     &(r1MissileDestroyerStat) },
+    { "MissileVolleyTime",        scriptSetReal32CB,    &(r1MissileDestroyerStat.missileVolleyTime),         &(r1MissileDestroyerStat) },
+    { "MissileLagVolleyTime",     scriptSetReal32CB,    &(r1MissileDestroyerStat.missileLagVolleyTime),      &(r1MissileDestroyerStat) },
 
     END_SCRIPT_STRUCT_ENTRY
 };
 
-void MissileDestroyerStaticInit(char *directory,char *filename,struct ShipStaticInfo *statinfo)
+/**
+ * @brief Initializes the ship using legacy attributes, if all of them were provided.
+ * @deprecated Backwards compatibility
+ * @param shipStaticInfo Ship static info.
+ * @param stat Ship statics.
+ */
+void MissileDestroyerStatInitLegacy(struct ShipStaticInfo *shipStaticInfo, MissileDestroyerStat *stat)
 {
-    udword i;
-    MissileDestroyerStatics *mdestroyerstat = (statinfo->shiprace == R1) ? &MissileDestroyerStaticRace1 : &MissileDestroyerStaticRace2;
-
-    statinfo->custstatinfo = mdestroyerstat;
-
-    scriptSetStruct(directory,filename,MissileDestroyerScriptTable,(ubyte *)mdestroyerstat);
-
-    for(i=0;i<NUM_TACTICS_TYPES;i++)
+    // Stop here if none of these were declared in the *.shp file.
+    // - MissileVolleyTime
+    // - MissileLagVolleyTime
+    // - MissileRegenerateTime
+    if (!(stat->missileVolleyTime && stat->missileLagVolleyTime && stat->missileRegenerateTime))
     {
-        mdestroyerstat->missiledestroyerGunRange[i] = statinfo->bulletRange[i];
-        mdestroyerstat->missiledestroyerTooCloseRange[i] = statinfo->minBulletRange[i] * 0.9f;
+        return;
+    }
+
+    // Assign fallbacks for the essential simple values.
+    stat->volleyFire.fireDelay = stat->missileVolleyTime;
+    stat->volleyFire.abilityCooldown = stat->missileLagVolleyTime;
+    stat->ammunition.reloadDelay = stat->missileRegenerateTime;
+
+    // Override only the missile launchers to allow volley fire.
+    sdword noOfWeapons = shipStaticInfo->gunStaticInfo->numGuns;
+    sdword weaponIndex;
+    GunStatic *gunStatic;
+
+    for (weaponIndex = 0; weaponIndex < noOfWeapons; weaponIndex++)
+    {
+        gunStatic = &shipStaticInfo->gunStaticInfo->gunstatics[weaponIndex];
+        bool canVolleyFire = gunStatic->guntype == GUN_MissileLauncher ? TRUE : gunStatic->canVolleyFire;
+        gunStatic->canVolleyFire = canVolleyFire;
+    }
+}
+
+void MissileDestroyerStatInit(char *directory, char *filename, struct ShipStaticInfo *shipStaticInfo)
+{
+    MissileDestroyerStat *stat = (shipStaticInfo->shiprace == R1) ? &r1MissileDestroyerStat : &r2MissileDestroyerStat;
+
+    scriptSetStruct(directory, filename, AmmunitionStatScriptTable, (ubyte *)&stat->ammunition);
+    scriptSetStruct(directory, filename, VolleyFireStatScriptTable, (ubyte *)&stat->volleyFire);
+    scriptSetStruct(directory, filename, MissileDestroyerScriptTable, (ubyte *)stat);
+
+    MissileDestroyerStatInitLegacy(shipStaticInfo, stat);
+
+    shipStaticInfo->custstatinfo = stat;
+
+    udword tacticIndex;
+    for (tacticIndex = 0; tacticIndex < NUM_TACTICS_TYPES; tacticIndex++)
+    {
+        stat->wpnRange[tacticIndex] = shipStaticInfo->bulletRange[tacticIndex];
+        stat->wpnMinRange[tacticIndex] = shipStaticInfo->minBulletRange[tacticIndex] * 0.9f;
     }
 }
 
@@ -71,201 +94,73 @@ void MissileDestroyerInit(Ship *ship)
 {
     MissileDestroyerSpec *spec = (MissileDestroyerSpec *)ship->ShipSpecifics;
 
-    spec->lasttimeRegeneratedMissiles = 0.0f;
-    spec->lasttimeFiredVolley = 0.0f;
-    spec->lasttimeDidSpecialTargeting = -100000.0f;
-    spec->curTargetIndex = 0;
-    spec->volleyState = VOLLEY_BEGIN;
+    volleyFireInit(&spec->volleyFire);
+    ammunitionInit(&spec->ammunition);
 }
 
-void MissileDestroyerAttack(Ship *ship,SpaceObjRotImpTarg *target,real32 maxdist)
+void MissileDestroyerAttack(Ship *ship, SpaceObjRotImpTarg *target, real32 maxdist)
 {
     ShipStaticInfo *shipstaticinfo = (ShipStaticInfo *)ship->staticinfo;
-    MissileDestroyerStatics *mdestroyerstat = (MissileDestroyerStatics *)shipstaticinfo->custstatinfo;
+    MissileDestroyerStat *stat = (MissileDestroyerStat *)shipstaticinfo->custstatinfo;
 
-    attackStraightForward(ship,target,mdestroyerstat->missiledestroyerGunRange[ship->tacticstype],mdestroyerstat->missiledestroyerTooCloseRange[ship->tacticstype]);
+    attackStraightForward(ship, target, stat->wpnRange[ship->tacticstype], stat->wpnMinRange[ship->tacticstype]);
 }
 
-void MissileDestroyerAttackPassive(Ship *ship,Ship *target,bool rotate)
+void MissileDestroyerAttackPassive(Ship *ship, Ship *target, bool rotate)
 {
     if ((rotate) & ((bool)((ShipStaticInfo *)(ship->staticinfo))->rotateToRetaliate))
     {
-        attackPassiveRotate(ship,target);
+        attackPassiveRotate(ship, target);
     }
     else
     {
-        attackPassive(ship,target);
+        attackPassive(ship, target);
     }
 }
 
 void MissileDestroyerHousekeep(Ship *ship)
 {
-    ShipStaticInfo *shipstaticinfo = (ShipStaticInfo *)ship->staticinfo;
+    ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
     MissileDestroyerSpec *spec = (MissileDestroyerSpec *)ship->ShipSpecifics;
-    MissileDestroyerStatics *mdestroyerstat = (MissileDestroyerStatics *)shipstaticinfo->custstatinfo;
-    sdword numGuns;
-    sdword i;
-    Gun *gun;
-    GunStatic *gunstatic;
-    sdword minMissiles;
-    sdword minIndex;
+    MissileDestroyerStat *stat = (MissileDestroyerStat *)shipStaticInfo->custstatinfo;
+    bool isVolleyFireReady = volleyFireIsReady(&spec->volleyFire, &stat->volleyFire);
 
-    if ((universe.totaltimeelapsed - spec->lasttimeDidSpecialTargeting) > mdestroyerstat->missileLagVolleyTime)
+    if (!isVolleyFireReady)
     {
-        if ((universe.totaltimeelapsed - spec->lasttimeRegeneratedMissiles) > mdestroyerstat->missileRegenerateTime)
-        {
-            spec->lasttimeRegeneratedMissiles = universe.totaltimeelapsed;
-            numGuns = ship->gunInfo->numGuns;
-
-            // find missile launcher with least missiles, and give it a missile
-            for (i=0,minIndex=-1,minMissiles=100000;i<numGuns;i++)
-            {
-                gunstatic = &shipstaticinfo->gunStaticInfo->gunstatics[i];
-                if (gunstatic->guntype == GUN_MissileLauncher)
-                {
-                    gun = &ship->gunInfo->guns[i];
-                    if (gun->numMissiles < gunstatic->maxMissiles)
-                    {
-                        if (gun->numMissiles < minMissiles)
-                        {
-                            minMissiles = gun->numMissiles;
-                            minIndex = i;
-                        }
-                    }
-                }
-            }
-
-            if (minIndex != -1)
-            {
-                ship->gunInfo->guns[minIndex].numMissiles++;
-            }
-        }
+        return;
     }
+
+    GunInfo *gunInfo = ship->gunInfo;
+    GunStaticInfo *gunStaticInfo = shipStaticInfo->gunStaticInfo;
+
+    ammunitionReloadLeastNoOfRoundsGun(
+        &spec->ammunition,
+        &stat->ammunition,
+        gunInfo,
+        gunStaticInfo);
 }
 
-bool MissileDestroyerSpecialTarget(Ship *ship,void *custom)
+bool MissileDestroyerSpecialTarget(Ship *ship, void *custom)
 {
-    SelectAnyCommand *targets;
-    sdword i;
-    sdword numShipsToTarget;
-    sdword numGuns;
-    Gun *gun;
-    real32 range;
-    GunStatic *gunstatic;
-    SpaceObjRotImpTarg *target;
-    ShipStaticInfo *shipstaticinfo;
-    MissileDestroyerSpec *spec;
-    MissileDestroyerStatics *mdestroyerstat;
-    bool firedSomeMissiles,triedToFire;
-    vector trajectory;
+    ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
+    MissileDestroyerSpec *spec = (MissileDestroyerSpec *)ship->ShipSpecifics;
+    MissileDestroyerStat *stat = (MissileDestroyerStat *)shipStaticInfo->custstatinfo;
 
-    spec = (MissileDestroyerSpec *)ship->ShipSpecifics;
-    shipstaticinfo = (ShipStaticInfo *)ship->staticinfo;
-    mdestroyerstat = (MissileDestroyerStatics *)shipstaticinfo->custstatinfo;
-
-    spec->lasttimeDidSpecialTargeting = universe.totaltimeelapsed;
-
-    // check that the "volley reload time" has passed
-    if ((universe.totaltimeelapsed - spec->lasttimeFiredVolley) > mdestroyerstat->missileVolleyTime)
-    {
-        spec->lasttimeFiredVolley = universe.totaltimeelapsed;
-    }
-    else
-    {
-        return FALSE;
-    }
-
-    targets = (SelectAnyCommand *)custom;
-    numShipsToTarget = targets->numTargets;
-
-    if (numShipsToTarget == 0)
-    {
-        // have destroyed targets, so we are done
-        spec->curTargetIndex = 0;
-        spec->volleyState = VOLLEY_BEGIN;
-        return TRUE;
-    }
-
-    if(spec->volleyState == VOLLEY_BEGIN)
-    {
-        spec->volleyState = VOLLEY_NOT_BEGIN;
-        //////////////////////
-        //Volley attack speech event!
-        //event num: COMM_MissleDest_VolleyAttack
-        //use battle chatter
-        if(ship->playerowner->playerIndex == universe.curPlayerIndex)
-        {
-            if (battleCanChatterAtThisTime(BCE_COMM_MissleDest_VolleyAttack, ship))
-            {
-                battleChatterAttempt(SOUND_EVENT_DEFAULT, BCE_COMM_MissleDest_VolleyAttack, ship, SOUND_EVENT_DEFAULT);
-            }
-        }
-        //////////////////////
-    }
-
-    if (spec->curTargetIndex >= numShipsToTarget)
-    {
-        spec->curTargetIndex = 0;
-    }
-
-    numGuns = ship->gunInfo->numGuns;
-    firedSomeMissiles = FALSE;
-    triedToFire=FALSE;
-    for (i=0;i<numGuns;i++)
-    {
-        gunstatic = &shipstaticinfo->gunStaticInfo->gunstatics[i];
-        if (gunstatic->guntype == GUN_MissileLauncher)
-        {
-            vecSub(trajectory,ship->collInfo.collPosition,targets->TargetPtr[spec->curTargetIndex]->collInfo.collPosition);
-            range = RangeToTarget(ship,targets->TargetPtr[spec->curTargetIndex],&trajectory);
-            gun = &ship->gunInfo->guns[i];
-            if(range < (gun->gunstatic->bulletrange*0.9f))
-            {
-                triedToFire=TRUE;
-                if (gunHasMissiles(gun))
-                {
-                    firedSomeMissiles = TRUE;
-
-                    target = targets->TargetPtr[spec->curTargetIndex];
-
-                    missileShoot(ship,gun,target);
-
-                    spec->curTargetIndex++;
-                    if (spec->curTargetIndex >= numShipsToTarget)
-                    {
-                        spec->curTargetIndex = 0;
-                    }
-                }
-            }
-        }
-    }
-
-    if (firedSomeMissiles)
-    {
-        aitrackZeroVelocity(ship);
-        return FALSE;
-    }
-    else if(triedToFire)
-    {
-        // all empty of missiles, so we are done
-        spec->curTargetIndex = 0;
-        spec->volleyState = VOLLEY_BEGIN;
-        return TRUE;
-    }
-    else
-    {
-        //didn't try to fire...so lets fly towards a target...lets pick...0
-        aishipFlyToShipAvoidingObjs(ship,(Ship *)targets->TargetPtr[0],AISHIP_FastAsPossible|AISHIP_PointInDirectionFlying,0.0f);
-    }
-    
-    return FALSE;
+    return volleyFireSpecialTarget(
+        ship,
+        custom,
+        &spec->volleyFire,
+        &stat->volleyFire,
+        volleyFireShootAllTargetsLumbering,
+        missileShoot,
+        BCE_COMM_MissleDest_VolleyAttack);
 }
 
 CustShipHeader MissileDestroyerHeader =
 {
     MissileDestroyer,
     sizeof(MissileDestroyerSpec),
-    MissileDestroyerStaticInit,
+    MissileDestroyerStatInit,
     NULL,
     MissileDestroyerInit,
     NULL,
@@ -282,4 +177,3 @@ CustShipHeader MissileDestroyerHeader =
     NULL,
     NULL
 };
-

--- a/src/Ships/MissileDestroyer.h
+++ b/src/Ships/MissileDestroyer.h
@@ -8,7 +8,41 @@
 #ifndef ___MISSILEDESTROYER_H
 #define ___MISSILEDESTROYER_H
 
+#include "Ammunition.h"
+#include "Attack.h"
 #include "SpaceObj.h"
+#include "VolleyFire.h"
+
+typedef struct
+{
+    VolleyFireSpec volleyFire;
+    AmmunitionSpec ammunition;
+} MissileDestroyerSpec;
+
+typedef struct
+{
+    AttackSideStepParameters sidestepParameters;
+    real32 wpnRange[NUM_TACTICS_TYPES];
+    real32 wpnMinRange[NUM_TACTICS_TYPES];
+    VolleyFireStat volleyFire;
+    AmmunitionStat ammunition;
+
+    /**
+     * The waiting duration (in seconds) before incrementing the ship's total ammunition by 1.
+     * @deprecated Use ammunition.reloadDelay
+     */
+    real32 missileRegenerateTime;
+    /**
+     * The delay (in seconds) between every weapon fire while the volley fire special ability is active.
+     * @deprecated Use volleyFire.fireDelay
+     */
+    real32 missileVolleyTime;
+    /**
+     * The delay (in seconds) before the volley fire special ability can be used again after its last activation.
+     * @deprecated Use volleyFire.abilityCooldown
+     */
+    real32 missileLagVolleyTime;
+} MissileDestroyerStat;
 
 extern CustShipHeader MissileDestroyerHeader;
 

--- a/src/Ships/P1MissileCorvette.c
+++ b/src/Ships/P1MissileCorvette.c
@@ -50,6 +50,7 @@ void P1MissileCorvetteStatInitLegacy(struct ShipStaticInfo *shipStaticInfo, P1Mi
     }
 
     // Assign fallbacks for the essential simple values.
+    shipStaticInfo->canVolleyFire = TRUE;
     stat->volleyFire.fireDelay = stat->missileVolleyTime;
     stat->volleyFire.abilityCooldown = stat->missileLagVolleyTime;
     stat->ammunition.reloadDelay = stat->missileRegenerateTime;

--- a/src/Ships/P1MissileCorvette.c
+++ b/src/Ships/P1MissileCorvette.c
@@ -7,64 +7,86 @@
 
 #include "P1MissileCorvette.h"
 
+#include "Ammunition.h"
 #include "Attack.h"
 #include "Battle.h"
 #include "DefaultShip.h"
 #include "Gun.h"
+#include "ObjTypes.h"
 #include "SoundEvent.h"
 #include "StatScript.h"
 #include "Universe.h"
+#include "VolleyFire.h"
 
-#define VOLLEY_BEGIN 10
-#define VOLLEY_NOT_BEGIN 20
+P1MissileCorvetteStat p1MissileCorvetteStat;
 
-typedef struct
-{
-    AttackSideStep attacksidestep;
-    real32 lasttimeRegeneratedMissiles;
-    real32 lasttimeFiredVolley;
-    real32 lasttimeDidSpecialTargeting;
-    sdword curTargetIndex;
-    sdword volleyState;
-} P1MissileCorvetteSpec;
-
-typedef struct
-{
-    real32 missilecorvetteGunRange[NUM_TACTICS_TYPES];
-    real32 missilecorvetteTooCloseRange[NUM_TACTICS_TYPES];
-    real32 missileRegenerateTime;
-    real32 missileVolleyTime;
-    real32 missileLagVolleyTime;
-    AttackSideStepParameters sidestepParameters;
-} P1MissileCorvetteStatics;
-
-P1MissileCorvetteStatics P1MissileCorvetteStatic;
-
+/**
+ * @deprecated We should use the new namespaced API from here on out.
+ */
 scriptStructEntry P1MissileCorvetteScriptTable[] =
 {
-    { "MissileRegenerateTime",scriptSetReal32CB, &(P1MissileCorvetteStatic.missileRegenerateTime), &(P1MissileCorvetteStatic) },
-    { "MissileVolleyTime",scriptSetReal32CB, &(P1MissileCorvetteStatic.missileVolleyTime), &(P1MissileCorvetteStatic) },
-    { "MissileLagVolleyTime",scriptSetReal32CB, &(P1MissileCorvetteStatic.missileLagVolleyTime), &(P1MissileCorvetteStatic) },
+    { "MissileRegenerateTime",    scriptSetReal32CB,    &(p1MissileCorvetteStat.missileRegenerateTime),    &(p1MissileCorvetteStat) },
+    { "MissileVolleyTime",        scriptSetReal32CB,    &(p1MissileCorvetteStat.missileVolleyTime),        &(p1MissileCorvetteStat) },
+    { "MissileLagVolleyTime",     scriptSetReal32CB,    &(p1MissileCorvetteStat.missileLagVolleyTime),     &(p1MissileCorvetteStat) },
 
     END_SCRIPT_STRUCT_ENTRY
 };
 
-void P1MissileCorvetteStaticInit(char *directory,char *filename,struct ShipStaticInfo *statinfo)
+/**
+ * @brief Initializes the ship using legacy attributes, if all of them were provided.
+ * @deprecated Backwards compatibility
+ * @param shipStaticInfo Ship static info.
+ * @param stat Ship statics.
+ */
+void P1MissileCorvetteStatInitLegacy(struct ShipStaticInfo *shipStaticInfo, P1MissileCorvetteStat *stat)
 {
-    udword i;
-    P1MissileCorvetteStatics *corvstat = &P1MissileCorvetteStatic;
-
-    memset(corvstat, 0, sizeof(P1MissileCorvetteStatics));
-
-    scriptSetStruct(directory,filename,AttackSideStepParametersScriptTable,(ubyte *)&corvstat->sidestepParameters);
-    scriptSetStruct(directory,filename,P1MissileCorvetteScriptTable,(ubyte *)corvstat);
-
-    statinfo->custstatinfo = corvstat;
-
-    for(i=0;i<NUM_TACTICS_TYPES;i++)
+    // Stop here if none of these were declared in the *.shp file.
+    // - MissileVolleyTime
+    // - MissileLagVolleyTime
+    // - MissileRegenerateTime
+    if (!(stat->missileVolleyTime && stat->missileLagVolleyTime && stat->missileRegenerateTime))
     {
-        corvstat->missilecorvetteGunRange[i] = statinfo->bulletRange[i];
-        corvstat->missilecorvetteTooCloseRange[i] = statinfo->minBulletRange[i] * 0.9f;
+        return;
+    }
+
+    // Assign fallbacks for the essential simple values.
+    stat->volleyFire.fireDelay = stat->missileVolleyTime;
+    stat->volleyFire.abilityCooldown = stat->missileLagVolleyTime;
+    stat->ammunition.reloadDelay = stat->missileRegenerateTime;
+
+    // Override only the missile launchers to allow volley fire.
+    sdword noOfWeapons = shipStaticInfo->gunStaticInfo->numGuns;
+    sdword weaponIndex;
+    GunStatic *gunStatic;
+
+    for (weaponIndex = 0; weaponIndex < noOfWeapons; weaponIndex++)
+    {
+        gunStatic = &shipStaticInfo->gunStaticInfo->gunstatics[weaponIndex];
+        bool canVolleyFire = gunStatic->guntype == GUN_MissileLauncher ? TRUE : gunStatic->canVolleyFire;
+        gunStatic->canVolleyFire = canVolleyFire;
+    }
+}
+
+void P1MissileCorvetteStatInit(char *directory, char *filename, struct ShipStaticInfo *shipStaticInfo)
+{
+    P1MissileCorvetteStat *stat = &p1MissileCorvetteStat;
+
+    memset(stat, 0, sizeof(P1MissileCorvetteStat));
+
+    scriptSetStruct(directory, filename, AttackSideStepParametersScriptTable, (ubyte *)&stat->sidestepParameters);
+    scriptSetStruct(directory, filename, AmmunitionStatScriptTable, (ubyte *)&stat->ammunition);
+    scriptSetStruct(directory, filename, VolleyFireStatScriptTable, (ubyte *)&stat->volleyFire);
+    scriptSetStruct(directory, filename, P1MissileCorvetteScriptTable, (ubyte *)stat);
+
+    P1MissileCorvetteStatInitLegacy(shipStaticInfo, stat);
+
+    shipStaticInfo->custstatinfo = stat;
+
+    udword tacticIndex;
+    for (tacticIndex = 0; tacticIndex < NUM_TACTICS_TYPES; tacticIndex++)
+    {
+        stat->wpnRange[tacticIndex] = shipStaticInfo->bulletRange[tacticIndex];
+        stat->wpnMinRange[tacticIndex] = shipStaticInfo->minBulletRange[tacticIndex] * 0.9f;
     }
 }
 
@@ -73,185 +95,134 @@ void P1MissileCorvetteInit(Ship *ship)
     P1MissileCorvetteSpec *spec = (P1MissileCorvetteSpec *)ship->ShipSpecifics;
 
     attackSideStepInit(&spec->attacksidestep);
-
-    spec->lasttimeRegeneratedMissiles = 0.0f;
-    spec->lasttimeFiredVolley = 0.0f;
-    spec->lasttimeDidSpecialTargeting = -100000.0f;
-    spec->curTargetIndex = 0;
-    spec->volleyState = VOLLEY_BEGIN;
+    volleyFireInit(&spec->volleyFire);
+    ammunitionInit(&spec->ammunition);
 }
 
-void P1MissileCorvetteAttack(Ship *ship,SpaceObjRotImpTarg *target,real32 maxdist)
+void P1MissileCorvetteAttack(Ship *ship, SpaceObjRotImpTarg *target, real32 maxdist)
 {
     P1MissileCorvetteSpec *spec = (P1MissileCorvetteSpec *)ship->ShipSpecifics;
-    P1MissileCorvetteStatics *corvstat = (P1MissileCorvetteStatics *)((ShipStaticInfo *)ship->staticinfo)->custstatinfo;
+    P1MissileCorvetteStat *stat = (P1MissileCorvetteStat *)((ShipStaticInfo *)ship->staticinfo)->custstatinfo;
 
-    attackSideStep(ship,target,&spec->attacksidestep,&corvstat->sidestepParameters);
+    attackSideStep(ship, target, &spec->attacksidestep, &stat->sidestepParameters);
 }
 
-void P1MissileCorvetteAttackPassive(Ship *ship,Ship *target,bool rotate)
+void P1MissileCorvetteAttackPassive(Ship *ship, Ship *target, bool rotate)
 {
     if ((rotate) & ((bool)((ShipStaticInfo *)(ship->staticinfo))->rotateToRetaliate))
     {
-        attackPassiveRotate(ship,target);
+        attackPassiveRotate(ship, target);
     }
     else
     {
-        attackPassive(ship,target);
+        attackPassive(ship, target);
     }
 }
 
 void P1MissileCorvetteHousekeep(Ship *ship)
 {
-    ShipStaticInfo *shipstaticinfo = (ShipStaticInfo *)ship->staticinfo;
+    ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
     P1MissileCorvetteSpec *spec = (P1MissileCorvetteSpec *)ship->ShipSpecifics;
-    P1MissileCorvetteStatics *mcorvettestat = (P1MissileCorvetteStatics *)shipstaticinfo->custstatinfo;
-    sdword numGuns;
-    sdword i;
-    Gun *gun;
-    GunStatic *gunstatic;
-    sdword minMissiles;
-    sdword minIndex;
+    P1MissileCorvetteStat *stat = (P1MissileCorvetteStat *)shipStaticInfo->custstatinfo;
+    bool isVolleyFireReady = volleyFireIsReady(&spec->volleyFire, &stat->volleyFire);
 
-    if ((universe.totaltimeelapsed - spec->lasttimeDidSpecialTargeting) > mcorvettestat->missileLagVolleyTime)
+    if (!isVolleyFireReady)
     {
-        if ((universe.totaltimeelapsed - spec->lasttimeRegeneratedMissiles) > mcorvettestat->missileRegenerateTime)
+        return;
+    }
+
+    GunInfo *gunInfo = ship->gunInfo;
+    GunStaticInfo *gunStaticInfo = shipStaticInfo->gunStaticInfo;
+
+    ammunitionReloadLeastNoOfRoundsGun(
+        &spec->ammunition,
+        &stat->ammunition,
+        gunInfo,
+        gunStaticInfo);
+}
+
+bool P1MissileCorvetteSpecialTargetAttack(Ship *ship, VolleyFireSpec *volleyFireSpec, VolleyFireStat *volleyFireStat, SelectAnyCommand *targets)
+{
+    ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
+
+    // Targets
+    SpaceObjRotImpTarg *target;
+    sdword noOfShipsToTarget = targets->numTargets;
+
+    // Weapons
+    Gun *gun;
+    GunStatic *gunStatic;
+    sdword gunIndex;
+    sdword noOfGuns = ship->gunInfo->numGuns;
+    bool hasFiredAtLeastOnce = FALSE;
+
+    // Correct the current target index if it's out of bounds from the last attempt.
+    if (volleyFireSpec->currentTargetIndex >= noOfShipsToTarget)
+    {
+        volleyFireSetCurrentTargetIndex(volleyFireSpec, 0);
+    }
+
+    // Attempt to attack each target.
+    for (gunIndex = 0; gunIndex < noOfGuns; gunIndex++)
+    {
+        target = targets->TargetPtr[volleyFireSpec->currentTargetIndex];
+        gunStatic = &shipStaticInfo->gunStaticInfo->gunstatics[gunIndex];
+        gun = &ship->gunInfo->guns[gunIndex];
+
+        // Break early if this weapon cannot volley fire.
+        if (!(gunStatic->canVolleyFire))
         {
-            spec->lasttimeRegeneratedMissiles = universe.totaltimeelapsed;
-            numGuns = ship->gunInfo->numGuns;
-
-            // find missile launcher with least missiles, and give it a missile
-            for (i=0,minIndex=-1,minMissiles=100000;i<numGuns;i++)
-            {
-                gunstatic = &shipstaticinfo->gunStaticInfo->gunstatics[i];
-                if (gunstatic->guntype == GUN_MissileLauncher)
-                {
-                    gun = &ship->gunInfo->guns[i];
-                    if (gun->numMissiles < gunstatic->maxMissiles)
-                    {
-                        if (gun->numMissiles < minMissiles)
-                        {
-                            minMissiles = gun->numMissiles;
-                            minIndex = i;
-                        }
-                    }
-                }
-            }
-
-            if (minIndex != -1)
-            {
-                ship->gunInfo->guns[minIndex].numMissiles++;
-            }
+            continue;
         }
+
+        // Break early if this weapon has no ammunition remaining.
+        if (!gunHasAmmunition(gun))
+        {
+            continue;
+        }
+
+        hasFiredAtLeastOnce = TRUE;
+        missileShoot(ship, gun, target);
+
+        sdword nextTargetIndex = volleyFireGetNextTargetIndex(volleyFireSpec->currentTargetIndex, noOfShipsToTarget);
+        volleyFireSetCurrentTargetIndex(volleyFireSpec, nextTargetIndex);
+    }
+
+    if (hasFiredAtLeastOnce)
+    {
+        return FALSE;
+    }
+    // Stop here and reset everything if the weapons are out of ammunition.
+    else
+    {
+        volleyFireSetBattleChatterBusy(volleyFireSpec, FALSE);
+        volleyFireSetCurrentTargetIndex(volleyFireSpec, 0);
+
+        return TRUE;
     }
 }
 
-bool P1MissileCorvetteSpecialTarget(Ship *ship,void *custom)
+bool P1MissileCorvetteSpecialTarget(Ship *ship, void *custom)
 {
-    SelectAnyCommand *targets;
-    sdword i;
-    sdword numShipsToTarget;
-    sdword numGuns;
-    Gun *gun;
-    GunStatic *gunstatic;
-    SpaceObjRotImpTarg *target;
-    ShipStaticInfo *shipstaticinfo;
-    P1MissileCorvetteSpec *spec;
-    P1MissileCorvetteStatics *mcorvettestat;
-    bool firedSomeMissiles;
+    ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
+    P1MissileCorvetteSpec *spec = (P1MissileCorvetteSpec *)ship->ShipSpecifics;
+    P1MissileCorvetteStat *stat = (P1MissileCorvetteStat *)shipStaticInfo->custstatinfo;
 
-    spec = (P1MissileCorvetteSpec *)ship->ShipSpecifics;
-    shipstaticinfo = (ShipStaticInfo *)ship->staticinfo;
-    mcorvettestat = (P1MissileCorvetteStatics *)shipstaticinfo->custstatinfo;
-
-    spec->lasttimeDidSpecialTargeting = universe.totaltimeelapsed;
-
-    // check that the "volley reload time" has passed
-    if ((universe.totaltimeelapsed - spec->lasttimeFiredVolley) > mcorvettestat->missileVolleyTime)
-    {
-        spec->lasttimeFiredVolley = universe.totaltimeelapsed;
-    }
-    else
-    {
-        return FALSE;
-    }
-
-    targets = (SelectAnyCommand *)custom;
-    numShipsToTarget = targets->numTargets;
-
-    if (numShipsToTarget == 0)
-    {
-        // have destroyed targets, so we are done
-        spec->curTargetIndex = 0;
-        spec->volleyState = VOLLEY_BEGIN;
-        return TRUE;
-    }
-
-    if(spec->volleyState == VOLLEY_BEGIN)
-    {
-        spec->volleyState = VOLLEY_NOT_BEGIN;
-        //////////////////////
-        //Volley attack speech event!
-        //event num: COMM_MissleDest_VolleyAttack
-        //use battle chatter
-        if(ship->playerowner->playerIndex == universe.curPlayerIndex)
-        {
-            if (battleCanChatterAtThisTime(BCE_COMM_MissleDest_VolleyAttack, ship))
-            {
-                battleChatterAttempt(SOUND_EVENT_DEFAULT, BCE_COMM_MissleDest_VolleyAttack, ship, SOUND_EVENT_DEFAULT);
-            }
-        }
-        //////////////////////
-    }
-
-    if (spec->curTargetIndex >= numShipsToTarget)
-    {
-        spec->curTargetIndex = 0;
-    }
-
-    numGuns = ship->gunInfo->numGuns;
-    firedSomeMissiles = FALSE;
-    for (i=0;i<numGuns;i++)
-    {
-        gunstatic = &shipstaticinfo->gunStaticInfo->gunstatics[i];
-        if (gunstatic->guntype == GUN_MissileLauncher)
-        {
-            gun = &ship->gunInfo->guns[i];
-            if (gunHasMissiles(gun))
-            {
-                firedSomeMissiles = TRUE;
-
-                target = targets->TargetPtr[spec->curTargetIndex];
-
-                missileShoot(ship,gun,target);
-
-                spec->curTargetIndex++;
-                if (spec->curTargetIndex >= numShipsToTarget)
-                {
-                    spec->curTargetIndex = 0;
-                }
-            }
-        }
-    }
-
-    if (firedSomeMissiles)
-    {
-        return FALSE;
-    }
-    else
-    {
-        // all empty of missiles, so we are done
-        spec->curTargetIndex = 0;
-        spec->volleyState = VOLLEY_BEGIN;
-        return TRUE;
-    }
+    return volleyFireSpecialTarget(
+        ship,
+        custom,
+        &spec->volleyFire,
+        &stat->volleyFire,
+        volleyFireShootAllTargetsDrifting,
+        missileShoot,
+        BCE_COMM_MissleDest_VolleyAttack);
 }
 
 CustShipHeader P1MissileCorvetteHeader =
 {
     P1MissileCorvette,
     sizeof(P1MissileCorvetteSpec),
-    P1MissileCorvetteStaticInit,
+    P1MissileCorvetteStatInit,
     NULL,
     P1MissileCorvetteInit,
     NULL,
@@ -268,4 +239,3 @@ CustShipHeader P1MissileCorvetteHeader =
     NULL,
     NULL
 };
-

--- a/src/Ships/P1MissileCorvette.c
+++ b/src/Ships/P1MissileCorvette.c
@@ -13,9 +13,7 @@
 #include "DefaultShip.h"
 #include "Gun.h"
 #include "ObjTypes.h"
-#include "SoundEvent.h"
 #include "StatScript.h"
-#include "Universe.h"
 #include "VolleyFire.h"
 
 P1MissileCorvetteStat p1MissileCorvetteStat;
@@ -208,15 +206,15 @@ bool P1MissileCorvetteSpecialTarget(Ship *ship, void *custom)
     ShipStaticInfo *shipStaticInfo = (ShipStaticInfo *)ship->staticinfo;
     P1MissileCorvetteSpec *spec = (P1MissileCorvetteSpec *)ship->ShipSpecifics;
     P1MissileCorvetteStat *stat = (P1MissileCorvetteStat *)shipStaticInfo->custstatinfo;
+    SelectAnyCommand *targets = (SelectAnyCommand *)custom;
 
     return volleyFireSpecialTarget(
         ship,
-        custom,
+        targets,
         &spec->volleyFire,
         &stat->volleyFire,
-        volleyFireShootAllTargetsDrifting,
-        missileShoot,
-        BCE_COMM_MissleDest_VolleyAttack);
+        BCE_COMM_MissleDest_VolleyAttack,
+        P1MissileCorvetteSpecialTargetAttack);
 }
 
 CustShipHeader P1MissileCorvetteHeader =

--- a/src/Ships/P1MissileCorvette.h
+++ b/src/Ships/P1MissileCorvette.h
@@ -8,7 +8,42 @@
 #ifndef ___P1MISSILECORVETTE_H
 #define ___P1MISSILECORVETTE_H
 
+#include "Ammunition.h"
+#include "Attack.h"
 #include "SpaceObj.h"
+#include "VolleyFire.h"
+
+typedef struct
+{
+    AttackSideStep attacksidestep;
+    VolleyFireSpec volleyFire;
+    AmmunitionSpec ammunition;
+} P1MissileCorvetteSpec;
+
+typedef struct
+{
+    AttackSideStepParameters sidestepParameters;
+    real32 wpnRange[NUM_TACTICS_TYPES];
+    real32 wpnMinRange[NUM_TACTICS_TYPES];
+    VolleyFireStat volleyFire;
+    AmmunitionStat ammunition;
+
+    /**
+     * The waiting duration (in seconds) before incrementing the ship's total ammunition by 1.
+     * @deprecated Use ammunition.reloadDelay
+     */
+    real32 missileRegenerateTime;
+    /**
+     * The delay (in seconds) between every weapon fire while the volley fire special ability is active.
+     * @deprecated Use volleyFire.fireDelay
+     */
+    real32 missileVolleyTime;
+    /**
+     * The delay (in seconds) before the volley fire special ability can be used again after its last activation.
+     * @deprecated Use volleyFire.abilityCooldown
+     */
+    real32 missileLagVolleyTime;
+} P1MissileCorvetteStat;
 
 extern CustShipHeader P1MissileCorvetteHeader;
 


### PR DESCRIPTION
## Checklist

### Changes
- Add shared modules.
- Decouple volley fire and ammunition logic from their implementations at the ship level.

### Tests
- [x] Missile launching ships have no deviations from original behavior.
- [x] Mine laying ships have no deviations from original behavior.
- [x] Shared modules can be applied to other ship types.
- [ ] New configuration attributes for modding are backward compatible with old ones.
- [ ] Windows
- [ ] Mac
- [ ] Linux

## Changelog

## Known issues