### PR TITLE
Fix: set ion beam length ETG script variable correctly

### DIFF
--- a/src/Game/Collision.c
+++ b/src/Game/Collision.c
@@ -1463,7 +1463,7 @@ void collCheckShipDerelictColl(blob *thisBlob)
     real32 maxdistCollPossible = 0.0;
     real32 distcheck           = 0.0;
     real32 absdistcheck        = 0.0;
-    
+
     vector distvector;
 
 
@@ -1927,7 +1927,7 @@ void collCheckBeamColl(blob *thisBlob,Bullet *bullet)
     //adjust length of effect associated with bullet, if applicable
     if (bullet->effect != NULL)
     {
-        ((real32 *)bullet->effect->variable)[ETG_LengthVariable] = bullet->beamtraveldist;
+        ((real32 *)bullet->effect->variable)[SCALESHIFT(ETG_LengthVariable)] = bullet->beamtraveldist;
     }
 }
 
@@ -2960,5 +2960,3 @@ void collCheckAllBulletMissileCollisions(void)
         collCheckMissileMineColl(thisBlob);
     }
 }
-
-


### PR DESCRIPTION
This fixes #16 where the ion beams go through the target ship.

The length variable is set incorrectly on non 32 bit builds.

![Screenshot from 2020-12-28 23-47-41](https://user-images.githubusercontent.com/593029/103247421-20761200-4967-11eb-86af-be21390f458e.png)

Please test!
I will see if there are any other instances of incorrectly set ETG script variables.
